### PR TITLE
feat: 엔티티 설정 및 api gateway 인증정보 조회용 security설정

### DIFF
--- a/company-service/build.gradle
+++ b/company-service/build.gradle
@@ -25,7 +25,21 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // PostgresSQL
+    runtimeOnly 'org.postgresql:postgresql'
+
+    // Hibernate Spatial
+    implementation 'org.hibernate.orm:hibernate-spatial:6.6.4.Final'
+    // Java Topology Suite
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
+    implementation 'org.locationtech.jts.io:jts-io-common:1.19.0'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/CompanyServiceApplication.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/CompanyServiceApplication.java
@@ -2,8 +2,10 @@ package com.shoonglogitics.companyservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CompanyServiceApplication {
 
 	public static void main(String[] args) {

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAggregateRoot.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAggregateRoot.java
@@ -44,12 +44,6 @@ public abstract class BaseAggregateRoot<A extends BaseAggregateRoot<A>>
 	private Long deletedBy;
 
 	@Override
-	public void update(Long userId) {
-		this.updatedAt = LocalDateTime.now();
-		this.updatedBy = userId;
-	}
-
-	@Override
 	public void softDelete(Long userId) {
 		this.deletedAt = LocalDateTime.now();
 		this.deletedBy = userId;

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAggregateRoot.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAggregateRoot.java
@@ -1,0 +1,62 @@
+package com.shoonglogitics.companyservice.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AbstractAggregateRoot;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseAggregateRoot<A extends BaseAggregateRoot<A>>
+	extends AbstractAggregateRoot<A>
+	implements BaseAuditEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	@Column(name = "created_by", updatable = false)
+	private Long createdBy;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@LastModifiedBy
+	@Column(name = "updated_by")
+	private Long updatedBy;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+
+	@Override
+	public void update(Long userId) {
+		this.updatedAt = LocalDateTime.now();
+		this.updatedBy = userId;
+	}
+
+	@Override
+	public void softDelete(Long userId) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = userId;
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return this.deletedAt != null;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAuditEntity.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAuditEntity.java
@@ -1,0 +1,16 @@
+package com.shoonglogitics.companyservice.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+public interface BaseAuditEntity {
+	LocalDateTime getCreatedAt();
+	Long getCreatedBy();
+	LocalDateTime getUpdatedAt();
+	Long getUpdatedBy();
+	LocalDateTime getDeletedAt();
+	Long getDeletedBy();
+
+	void update(Long userId);
+	void softDelete(Long userId);
+	boolean isDeleted();
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAuditEntity.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseAuditEntity.java
@@ -10,7 +10,6 @@ public interface BaseAuditEntity {
 	LocalDateTime getDeletedAt();
 	Long getDeletedBy();
 
-	void update(Long userId);
 	void softDelete(Long userId);
 	boolean isDeleted();
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseEntity.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseEntity.java
@@ -26,8 +26,8 @@ public abstract class BaseEntity implements BaseAuditEntity {
 	@Column(name = "created_by", updatable = false)
 	private Long createdBy;
 
-	@Column(name = "updated_at")
 	@LastModifiedDate
+	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
 	@LastModifiedBy

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseEntity.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseEntity.java
@@ -1,0 +1,59 @@
+package com.shoonglogitics.companyservice.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity implements BaseAuditEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	@Column(name = "created_by", updatable = false)
+	private Long createdBy;
+
+	@Column(name = "updated_at")
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	@LastModifiedBy
+	@Column(name = "updated_by")
+	private Long updatedBy;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+
+	@Override
+	public void update(Long userId) {
+		this.updatedAt = LocalDateTime.now();
+		this.updatedBy = userId;
+	}
+
+	@Override
+	public void softDelete(Long userId) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = userId;
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return this.deletedAt != null;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseEntity.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/entity/BaseEntity.java
@@ -41,12 +41,6 @@ public abstract class BaseEntity implements BaseAuditEntity {
 	private Long deletedBy;
 
 	@Override
-	public void update(Long userId) {
-		this.updatedAt = LocalDateTime.now();
-		this.updatedBy = userId;
-	}
-
-	@Override
 	public void softDelete(Long userId) {
 		this.deletedAt = LocalDateTime.now();
 		this.deletedBy = userId;

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/vo/UserRoleType.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/vo/UserRoleType.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.companyservice.domain.common.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRoleType {
+	MASTER(Authority.MASTER),
+	HUB_MANAGER(Authority.HUB_MANAGER),
+	DELIVERY_MANAGER(Authority.DELIVERY_MANAGER),
+	SUPPLIER_MANAGER(Authority.SUPPLIER_MANAGER);
+
+	private final String authority;
+
+	UserRoleType(String authority) {
+		this.authority = authority;
+	}
+
+	public static class Authority {
+		public static final String MASTER = "ROLE_MASTER";
+		public static final String HUB_MANAGER = "ROLE_HUB_MANAGER";
+		public static final String DELIVERY_MANAGER = "ROLE_DELIVERY_MANAGER";
+		public static final String SUPPLIER_MANAGER = "ROLE_SUPPLIER_MANAGER";
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/vo/UserRoleType.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/common/vo/UserRoleType.java
@@ -7,7 +7,7 @@ public enum UserRoleType {
 	MASTER(Authority.MASTER),
 	HUB_MANAGER(Authority.HUB_MANAGER),
 	DELIVERY_MANAGER(Authority.DELIVERY_MANAGER),
-	SUPPLIER_MANAGER(Authority.SUPPLIER_MANAGER);
+	COMPANY_MANAGER(Authority.COMPANY_MANAGER);
 
 	private final String authority;
 
@@ -19,6 +19,6 @@ public enum UserRoleType {
 		public static final String MASTER = "ROLE_MASTER";
 		public static final String HUB_MANAGER = "ROLE_HUB_MANAGER";
 		public static final String DELIVERY_MANAGER = "ROLE_DELIVERY_MANAGER";
-		public static final String SUPPLIER_MANAGER = "ROLE_SUPPLIER_MANAGER";
+		public static final String COMPANY_MANAGER = "ROLE_COMPANY_MANAGER";
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Company.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Company.java
@@ -1,0 +1,98 @@
+package com.shoonglogitics.companyservice.domain.company.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+import org.springframework.data.geo.Point;
+
+import com.shoonglogitics.companyservice.domain.common.entity.BaseAggregateRoot;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyAddress;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyLocation;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_company")
+@Where(clause = "deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Company extends BaseAggregateRoot<Company> {
+
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.TIME)
+	@Column(name = "id", columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(name = "p_hub_id", columnDefinition = "uuid")
+	private UUID hubId;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "address", column = @Column(name = "address", nullable = false)),
+		@AttributeOverride(name = "addressDetail", column = @Column(name = "address_detail", nullable = false)),
+		@AttributeOverride(name = "zipCode", column = @Column(name = "zip_code", nullable = false)),
+	})
+	private CompanyAddress address;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "location", column = @Column(name = "location", nullable = false, columnDefinition = "geometry(Point, 4326)"))
+	})
+	private CompanyLocation location;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false)
+	private CompanyType type;
+
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "p_company_id")
+	private List<Product> products = new ArrayList<>();
+
+
+	public static Company create(
+		UUID hubId,
+		String name,
+		String address,
+		String addressDetail,
+		String zipCode,
+		Point location,
+		CompanyType type,
+		List<Product> products
+	) {
+		Company company = new Company();
+		company.hubId = hubId;
+		company.name = name;
+		company.address = CompanyAddress.of(address, addressDetail, zipCode);
+		company.location = CompanyLocation.of(location);
+		company.type = type;
+
+		if (products != null && !products.isEmpty()) {
+			for (Product product : products) {
+				company.products.add(product);
+			}
+		}
+
+		return company;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Product.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Product.java
@@ -1,0 +1,61 @@
+package com.shoonglogitics.companyservice.domain.company.entity;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+
+import com.shoonglogitics.companyservice.domain.common.entity.BaseEntity;
+import com.shoonglogitics.companyservice.domain.company.vo.ProductInfo;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_product")
+@Where(clause = "deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.TIME)
+	@Column(name = "id", columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(name = "p_product_category_id", columnDefinition = "uuid")
+	private UUID productCategoryId;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false)),
+		@AttributeOverride(name = "price", column = @Column(name = "price", nullable = false)),
+		@AttributeOverride(name = "description", column = @Column(name = "description", nullable = false, columnDefinition = "text"))
+	})
+	private ProductInfo productInfo;
+
+	public static Product create(
+		UUID productCategoryId,
+		String name,
+		Integer price,
+		String description
+	) {
+		Product product = new Product();
+		product.productCategoryId = productCategoryId;
+		product.productInfo = ProductInfo.of(name, price, description);
+
+		return product;
+	}
+
+	public void changeCategory(UUID newCategoryId) {
+		this.productCategoryId = newCategoryId;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/CompanyRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/CompanyRepository.java
@@ -1,0 +1,7 @@
+package com.shoonglogitics.companyservice.domain.company.repository;
+
+import com.shoonglogitics.companyservice.domain.company.entity.Company;
+
+public interface CompanyRepository {
+	Company save(Company company);
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/ProductCategoryRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/ProductCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.shoonglogitics.companyservice.domain.company.repository;
+
+import com.shoonglogitics.companyservice.domain.productcategory.entity.ProductCategory;
+
+public interface ProductCategoryRepository {
+	ProductCategory save(ProductCategory productCategory);
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/StockRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/StockRepository.java
@@ -1,0 +1,7 @@
+package com.shoonglogitics.companyservice.domain.company.repository;
+
+import com.shoonglogitics.companyservice.domain.stock.entity.Stock;
+
+public interface StockRepository {
+	Stock save(Stock company);
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/CompanyAddress.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/CompanyAddress.java
@@ -1,0 +1,25 @@
+package com.shoonglogitics.companyservice.domain.company.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyAddress {
+	private String address;
+	private String addressDetail;
+	private String zipCode;
+
+	public static CompanyAddress of(String address, String detail, String zipCode) {
+		CompanyAddress value = new CompanyAddress();
+		value.address = address;
+		value.addressDetail = detail;
+		value.zipCode = zipCode;
+		return value;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/CompanyLocation.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/CompanyLocation.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.companyservice.domain.company.vo;
+
+import org.springframework.data.geo.Point;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyLocation {
+	private Point location;
+
+	public static CompanyLocation of(Point point) {
+		CompanyLocation value = new CompanyLocation();
+		value.location = point;
+
+		return value;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/CompanyType.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/CompanyType.java
@@ -1,0 +1,13 @@
+package com.shoonglogitics.companyservice.domain.company.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CompanyType {
+	MANUFACTURER("생산업체"),
+	RECEIVER("공급업체");
+
+	private final String description;
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/ProductInfo.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/vo/ProductInfo.java
@@ -1,0 +1,36 @@
+package com.shoonglogitics.companyservice.domain.company.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductInfo {
+
+	private String name;
+	private Integer price;
+	private String description;
+
+	private ProductInfo(String name, Integer price, String description) {
+		validatePrice(price);
+
+		this.name = name;
+		this.price = price;
+		this.description = description;
+	}
+
+	public static ProductInfo of(String name, Integer price, String description) {
+		return new ProductInfo(name, price, description);
+	}
+
+	private void validatePrice(Integer price) {
+		if (price < 0) {
+			throw new IllegalArgumentException("상품가격은 음수일 수 없습니다.");
+		}
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/productcategory/entity/ProductCategory.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/productcategory/entity/ProductCategory.java
@@ -1,0 +1,31 @@
+package com.shoonglogitics.companyservice.domain.productcategory.entity;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+
+import com.shoonglogitics.companyservice.domain.common.entity.BaseAggregateRoot;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_product_category")
+@Where(clause = "deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductCategory extends BaseAggregateRoot<ProductCategory> {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.TIME)
+	@Column(name = "id", columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/entity/Stock.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/entity/Stock.java
@@ -1,0 +1,67 @@
+package com.shoonglogitics.companyservice.domain.stock.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+
+import com.shoonglogitics.companyservice.domain.common.entity.BaseAggregateRoot;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_stock")
+@Where(clause = "deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock extends BaseAggregateRoot<Stock> {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.TIME)
+	@Column(name = "id", columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(name = "amount", nullable = false)
+	private Integer amount;
+
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "p_stock_id")
+	private List<StockHistory> stockHistories = new ArrayList<>();
+
+	private Stock(Integer initialAmount) {
+		validateAmount(initialAmount);
+		this.amount = initialAmount;
+	}
+
+	public static Stock create(Integer initialAmount) {
+		Stock stock = new Stock(initialAmount);
+
+		// 초기 재고 이력 생성
+		StockHistory initialHistory = StockHistory.createForStockIn(
+			null,  // stockId는 save 후에 설정됨
+			0,
+			initialAmount,
+			initialAmount,
+			"초기 재고 등록"
+		);
+		stock.stockHistories.add(initialHistory);
+
+		return stock;
+	}
+
+	private void validateAmount(Integer amount) {
+		if (amount == null || amount < 0) {
+			throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
+		}
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/entity/StockHistory.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/entity/StockHistory.java
@@ -1,0 +1,116 @@
+package com.shoonglogitics.companyservice.domain.stock.entity;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+
+import com.shoonglogitics.companyservice.domain.common.entity.BaseEntity;
+import com.shoonglogitics.companyservice.domain.stock.vo.StockChange;
+import com.shoonglogitics.companyservice.domain.stock.vo.StockChangeType;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_stock_history")
+@Where(clause = "deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockHistory extends BaseEntity {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.TIME)
+	@Column(name = "id", columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(name = "p_stock_id", nullable = false, columnDefinition = "uuid")
+	private UUID stockId;
+
+	@Column(name = "p_order_id", columnDefinition = "uuid")
+	private UUID orderId;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "beforeAmount", column = @Column(name = "before_amount", nullable = false)),
+		@AttributeOverride(name = "changeAmount", column = @Column(name = "change_amount", nullable = false)),
+		@AttributeOverride(name = "afterAmount", column = @Column(name = "after_amount", nullable = false)),
+	})
+	private StockChange stockChange;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "change_type", nullable = false)
+	private StockChangeType changeType;
+
+	@Column(name = "reason")
+	private String reason;
+
+	public static StockHistory createForOrder(
+		UUID stockId,
+		UUID orderId,
+		Integer beforeAmount,
+		Integer changeAmount,
+		Integer afterAmount
+	) {
+		StockHistory history = new StockHistory();
+		history.stockId = stockId;
+		history.orderId = orderId;
+		history.stockChange = StockChange.of(beforeAmount, changeAmount, afterAmount);
+		history.changeType = StockChangeType.ORDER;
+		return history;
+	}
+
+	public static StockHistory createForOrderCancel(
+		UUID stockId,
+		UUID orderId,
+		Integer beforeAmount,
+		Integer changeAmount,
+		Integer afterAmount
+	) {
+		StockHistory history = new StockHistory();
+		history.stockId = stockId;
+		history.orderId = orderId;
+		history.stockChange = StockChange.of(beforeAmount, changeAmount, afterAmount);
+		history.changeType = StockChangeType.ORDER_CANCEL;
+		return history;
+	}
+
+	public static StockHistory createForStockIn(
+		UUID stockId,
+		Integer beforeAmount,
+		Integer changeAmount,
+		Integer afterAmount,
+		String reason
+	) {
+		StockHistory history = new StockHistory();
+		history.stockId = stockId;
+		history.stockChange = StockChange.of(beforeAmount, changeAmount, afterAmount);
+		history.changeType = StockChangeType.STOCK_IN;
+		history.reason = reason;
+		return history;
+	}
+
+	public static StockHistory createForStockOut(
+		UUID stockId,
+		Integer beforeAmount,
+		Integer changeAmount,
+		Integer afterAmount,
+		String reason
+	) {
+		StockHistory history = new StockHistory();
+		history.stockId = stockId;
+		history.stockChange = StockChange.of(beforeAmount, changeAmount, afterAmount);
+		history.changeType = StockChangeType.STOCK_OUT;
+		history.reason = reason;
+		return history;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/vo/StockChange.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/vo/StockChange.java
@@ -1,0 +1,44 @@
+package com.shoonglogitics.companyservice.domain.stock.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockChange {
+
+	private Integer beforeAmount;
+	private Integer changeAmount;
+	private Integer afterAmount;
+
+	private StockChange(Integer beforeAmount, Integer changeAmount, Integer afterAmount) {
+		validateStockChange(beforeAmount, changeAmount, afterAmount);
+
+		this.beforeAmount = beforeAmount;
+		this.changeAmount = changeAmount;
+		this.afterAmount = afterAmount;
+	}
+
+	public static StockChange of(Integer beforeAmount, Integer changeAmount, Integer afterAmount) {
+		return new StockChange(beforeAmount, changeAmount, afterAmount);
+	}
+
+	private void validateStockChange(Integer beforeAmount, Integer changeAmount, Integer afterAmount) {
+		if (beforeAmount < 0 || afterAmount < 0) {
+			throw new IllegalArgumentException("재고 수량은 음수일 수 없습니다.");
+		}
+
+		// 변경 전 + 변경량 = 변경 후 검증
+		if (beforeAmount + changeAmount != afterAmount) {
+			throw new IllegalArgumentException(
+				String.format("재고 변경 계산이 올바르지 않습니다. before: %d, change: %d, after: %d",
+					beforeAmount, changeAmount, afterAmount)
+			);
+		}
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/vo/StockChangeType.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/stock/vo/StockChangeType.java
@@ -1,0 +1,16 @@
+package com.shoonglogitics.companyservice.domain.stock.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockChangeType {
+	ORDER("주문", "주문으로 인한 재고 감소"),
+	ORDER_CANCEL("주문 취소", "주문 취소로 인한 재고 증가"),
+	STOCK_IN("입고", "입고로 인한 재고 증가"),
+	STOCK_OUT("출고", "출고로 인한 재고 감소");
+
+	private final String description;
+	private final String detail;
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/auditing/AuditorAwareImpl.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/auditing/AuditorAwareImpl.java
@@ -1,0 +1,28 @@
+package com.shoonglogitics.companyservice.infrastructure.auditing;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<Long> {
+
+	@Override
+	public Optional<Long> getCurrentAuditor() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return Optional.empty();
+		}
+
+		try {
+			String userId = (String) authentication.getPrincipal();
+			return Optional.of(Long.parseLong(userId));
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/RepositoryConfig.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/RepositoryConfig.java
@@ -1,0 +1,34 @@
+package com.shoonglogitics.companyservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.shoonglogitics.companyservice.domain.company.repository.CompanyRepository;
+import com.shoonglogitics.companyservice.domain.company.repository.ProductCategoryRepository;
+import com.shoonglogitics.companyservice.domain.company.repository.StockRepository;
+import com.shoonglogitics.companyservice.infrastructure.repository.CompanyRepositoryAdapter;
+import com.shoonglogitics.companyservice.infrastructure.repository.JpaCompanyRepository;
+import com.shoonglogitics.companyservice.infrastructure.repository.JpaProductCategoryRepository;
+import com.shoonglogitics.companyservice.infrastructure.repository.JpaStockRepository;
+import com.shoonglogitics.companyservice.infrastructure.repository.ProductCategoryRepositoryAdapter;
+import com.shoonglogitics.companyservice.infrastructure.repository.StockRepositoryAdapter;
+
+@Configuration
+public class RepositoryConfig {
+
+	@Bean
+	public CompanyRepository orderRepository(JpaCompanyRepository jpaCompanyRepository) {
+		return new CompanyRepositoryAdapter(jpaCompanyRepository);
+	}
+
+	@Bean
+	public ProductCategoryRepository productCategoryRepository(JpaProductCategoryRepository jpaProductCategoryRepository) {
+		return new ProductCategoryRepositoryAdapter(jpaProductCategoryRepository);
+	}
+
+	@Bean
+	public StockRepository stockRepository(JpaStockRepository jpaStockRepository) {
+		return new StockRepositoryAdapter(jpaStockRepository);
+	}
+}
+

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/SecurityConfig.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.shoonglogitics.companyservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.shoonglogitics.companyservice.infrastructure.filter.GatewayAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final GatewayAuthenticationFilter gatewayAuthenticationFilter;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.sessionManagement(session ->
+				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/actuator/**").permitAll()  // health check
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(gatewayAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/filter/GatewayAuthenticationFilter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/filter/GatewayAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.shoonglogitics.companyservice.infrastructure.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class GatewayAuthenticationFilter extends OncePerRequestFilter {
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final String USER_ROLE_HEADER = "X-User-Role";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String userId = request.getHeader(USER_ID_HEADER);
+		String role = request.getHeader(USER_ROLE_HEADER);
+
+		if (userId != null && role != null) {
+			try {
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(
+						userId,  // principal
+						null,    // credentials
+						List.of(new SimpleGrantedAuthority("ROLE_" + role))  // authorities
+					);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+
+			} catch (Exception e) {
+				log.error("인증 정보가 없습니다.");
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/CompanyRepositoryAdapter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/CompanyRepositoryAdapter.java
@@ -1,0 +1,19 @@
+package com.shoonglogitics.companyservice.infrastructure.repository;
+
+import org.springframework.stereotype.Component;
+
+import com.shoonglogitics.companyservice.domain.company.entity.Company;
+import com.shoonglogitics.companyservice.domain.company.repository.CompanyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyRepositoryAdapter implements CompanyRepository {
+	private final JpaCompanyRepository jpaCompanyRepository;
+
+	@Override
+	public Company save(Company company) {
+		return jpaCompanyRepository.save(company);
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaCompanyRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaCompanyRepository.java
@@ -1,0 +1,12 @@
+package com.shoonglogitics.companyservice.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.shoonglogitics.companyservice.domain.company.entity.Company;
+
+@Repository
+public interface JpaCompanyRepository extends JpaRepository<Company, UUID> {
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaProductCategoryRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaProductCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.shoonglogitics.companyservice.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.shoonglogitics.companyservice.domain.productcategory.entity.ProductCategory;
+
+@Repository
+public interface JpaProductCategoryRepository extends JpaRepository<ProductCategory, UUID> {
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaStockRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaStockRepository.java
@@ -1,0 +1,12 @@
+package com.shoonglogitics.companyservice.infrastructure.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.shoonglogitics.companyservice.domain.stock.entity.Stock;
+
+@Repository
+public interface JpaStockRepository extends JpaRepository<Stock, UUID> {
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/ProductCategoryRepositoryAdapter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/ProductCategoryRepositoryAdapter.java
@@ -1,0 +1,19 @@
+package com.shoonglogitics.companyservice.infrastructure.repository;
+
+import org.springframework.stereotype.Component;
+
+import com.shoonglogitics.companyservice.domain.company.repository.ProductCategoryRepository;
+import com.shoonglogitics.companyservice.domain.productcategory.entity.ProductCategory;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductCategoryRepositoryAdapter implements ProductCategoryRepository {
+	private final JpaProductCategoryRepository jpaProductCategoryRepository;
+
+	@Override
+	public ProductCategory save(ProductCategory productCategory) {
+		return jpaProductCategoryRepository.save(productCategory);
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/StockRepositoryAdapter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/StockRepositoryAdapter.java
@@ -1,0 +1,19 @@
+package com.shoonglogitics.companyservice.infrastructure.repository;
+
+import org.springframework.stereotype.Component;
+
+import com.shoonglogitics.companyservice.domain.company.repository.StockRepository;
+import com.shoonglogitics.companyservice.domain.stock.entity.Stock;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StockRepositoryAdapter implements StockRepository {
+	private final JpaStockRepository jpaStockRepository;
+
+	@Override
+	public Stock save(Stock stock) {
+		return jpaStockRepository.save(stock);
+	}
+}

--- a/company-service/src/main/resources/application-datasource.yml
+++ b/company-service/src/main/resources/application-datasource.yml
@@ -1,0 +1,101 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:postgresql://localhost:5432/company_service
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: qwer1234!
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5432/company_service
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: qwer1234!
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+        database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:postgresql://localhost:5432/company_service
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: qwer1234!
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    driver-class-name: org.postgresql.Driver
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+
+logging:
+  level:
+    org.hibernate: warn

--- a/company-service/src/main/resources/application.properties
+++ b/company-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=company-service

--- a/company-service/src/main/resources/application.yml
+++ b/company-service/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+server:
+  port: 8080
+
+spring:
+  profiles:
+    include:
+      - datasource


### PR DESCRIPTION
### 연관이슈(이슈번호)

### 변경사항
- 업체(Company), 상품(Product), 재고(Stock) 등 주요 도메인 엔티티 생성
- 각 도메인별 Value Object 및 연관관계 설정
- BaseEntity, BaseAggregateRoot 등 공통 엔티티 기반 구조 적용
- Repository 인터페이스 정의 및 기본 JPA 설정 추가
- Spring Security 기반 Gateway 인증 정보 설정
- 감사(audit) 데이터 주입 로직 수정 (SecurityContext 기반으로 사용자 정보 주입)
- UUID 기반 식별자 매핑 및 초기 데이터 생성 로직 반영

### 리뷰요청
- 유광열 튜터님 피드백을 반영하여 SecurityContext를 활용한 감사 데이터 주입 로직으로 수정했습니다.
구조나 적용 방식이 적절한지 확인 부탁드립니다.