### PR TITLE
Feat/user service/jwt

### DIFF
--- a/user-service/.gitignore
+++ b/user-service/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Q entity 방지용 ###
+/src/main/generated/

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
@@ -38,10 +39,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
-    
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -32,8 +32,10 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -44,9 +46,16 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+//Querydsl 추가
+clean {
+    delete file('src/main/generated')
+
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -25,7 +25,20 @@ repositories {
 }
 
 dependencies {
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+//@ComponentScan("com.shoonglogitics")
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
@@ -2,9 +2,10 @@ package com.shoonglogitics.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-//@ComponentScan("com.shoonglogitics")
+@ComponentScan("com.shoonglogitics")
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/CompanyManagerSignUpCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/CompanyManagerSignUpCommand.java
@@ -1,0 +1,32 @@
+package com.shoonglogitics.userservice.application.command;
+
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.vo.CompanyId;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CompanyManagerSignUpCommand extends SignUpUserCommand {
+
+	private CompanyId companyId;
+
+	@Builder
+	public CompanyManagerSignUpCommand(String userName, String password, Name name,
+		Email email, SlackId slackId, PhoneNumber phoneNumber,
+		CompanyId companyId) {
+		super(userName, password, SignupStatus.PENDING, name, email, slackId, phoneNumber);
+		this.companyId = companyId;
+	}
+
+	@Override
+	public UserRole getRole() {
+		return UserRole.COMPANY_MANAGER;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/HubManagerSignUpCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/HubManagerSignUpCommand.java
@@ -1,0 +1,32 @@
+package com.shoonglogitics.userservice.application.command;
+
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class HubManagerSignUpCommand extends SignUpUserCommand {
+
+	private HubId hubId;
+
+	@Builder
+	HubManagerSignUpCommand(String userName, String password, Name name,
+		Email email, SlackId slackId,
+		PhoneNumber phoneNumber, HubId hubId) {
+		super(userName, password, SignupStatus.PENDING, name, email, slackId, phoneNumber);
+		this.hubId = hubId;
+	}
+
+	@Override
+	public UserRole getRole() {
+		return UserRole.HUB_MANAGER;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/LoginUserCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/LoginUserCommand.java
@@ -1,0 +1,13 @@
+package com.shoonglogitics.userservice.application.command;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginUserCommand {
+
+	private String userName;
+	private String password;
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/MasterSignUpCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/MasterSignUpCommand.java
@@ -1,0 +1,27 @@
+package com.shoonglogitics.userservice.application.command;
+
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MasterSignUpCommand extends SignUpUserCommand {
+
+	@Builder
+	MasterSignUpCommand(String userName, String password, Name name,
+		Email email, SlackId slackId, PhoneNumber phoneNumber) {
+		super(userName, password, SignupStatus.PENDING, name, email, slackId, phoneNumber);
+	}
+
+	@Override
+	public UserRole getRole() {
+		return UserRole.MASTER;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/ShipperSignUpCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/ShipperSignUpCommand.java
@@ -1,0 +1,40 @@
+package com.shoonglogitics.userservice.application.command;
+
+import com.shoonglogitics.userservice.domain.entity.ShipperType;
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ShipperSignUpCommand extends SignUpUserCommand {
+
+	private ShipperType shipperType;
+	private HubId hubId;
+	private Integer order;
+	private Boolean isShippingAvailable;
+
+	@Builder
+	public ShipperSignUpCommand(String userName, String password, Name name,
+		Email email, SlackId slackId, PhoneNumber phoneNumber,
+		ShipperType shipperType, HubId hubId,
+		Integer order, Boolean isShippingAvailable) { // 필드 추가
+		super(userName, password, SignupStatus.PENDING, name, email, slackId, phoneNumber);
+		this.shipperType = shipperType;
+		this.hubId = hubId;
+		this.order = order;
+		this.isShippingAvailable = isShippingAvailable;
+	}
+
+	@Override
+	public UserRole getRole() {
+		return UserRole.SHIPPER;
+	}
+}
+

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/SignUpUserCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/SignUpUserCommand.java
@@ -1,0 +1,37 @@
+package com.shoonglogitics.userservice.application.command;
+
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Getter;
+
+@Getter
+public abstract class SignUpUserCommand {
+
+	private String userName;
+	private String password;
+	private SignupStatus signupStatus;
+	private Name name;
+	private Email email;
+	private SlackId slackId;
+	private PhoneNumber phoneNumber;
+
+	protected SignUpUserCommand(String userName, String password,
+		SignupStatus signupStatus, Name name, Email email, SlackId slackId,
+		PhoneNumber phoneNumber) {
+		this.userName = userName;
+		this.password = password;
+		this.signupStatus = signupStatus;
+		this.name = name;
+		this.email = email;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
+	}
+
+	public abstract UserRole getRole();
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/CompanyManagerViewResponseDto.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/CompanyManagerViewResponseDto.java
@@ -1,0 +1,34 @@
+package com.shoonglogitics.userservice.application.dto;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CompanyManagerViewResponseDto {
+
+	private Long companyManagerId;
+	private String name;
+	private String email;
+	private String phoneNumber;
+	private String slackId;
+	private UUID companyId;
+
+	public CompanyManagerViewResponseDto(
+		Long companyManagerId,
+		String name,
+		String email,
+		String phoneNumber,
+		String slackId,
+		UUID companyId) {
+
+		this.companyManagerId = companyManagerId;
+		this.name = name;
+		this.email = email;
+		this.phoneNumber = phoneNumber;
+		this.slackId = slackId;
+		this.companyId = companyId;
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/HubManagerViewResponseDto.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/HubManagerViewResponseDto.java
@@ -1,0 +1,37 @@
+package com.shoonglogitics.userservice.application.dto;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+public class HubManagerViewResponseDto {
+
+	private Long hubManagerId;
+	private String name;
+	private String email;
+	private String phoneNumber;
+	private String slackId;
+	private UUID hubId;  // HubManager 전용
+
+	public HubManagerViewResponseDto(
+		Long hubManagerId,
+		String name,
+		String email,
+		String phoneNumber,
+		String slackId,
+		UUID hubId) {
+
+		this.hubManagerId = hubManagerId;
+		this.name = name;
+		this.email = email;
+		this.phoneNumber = phoneNumber;
+		this.slackId = slackId;
+		this.hubId = hubId;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/MasterViewResponseDto.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/MasterViewResponseDto.java
@@ -1,0 +1,32 @@
+package com.shoonglogitics.userservice.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+public class MasterViewResponseDto {
+
+	private Long masterId;
+	private String name;
+	private String email;
+	private String phoneNumber;
+	private String slackId;
+
+	public MasterViewResponseDto(
+		Long masterId,
+		String name,
+		String email,
+		String phoneNumber,
+		String slackId) {
+
+		this.masterId = masterId;
+		this.name = name;
+		this.email = email;
+		this.phoneNumber = phoneNumber;
+		this.slackId = slackId;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/PageResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/PageResponse.java
@@ -1,0 +1,31 @@
+package com.shoonglogitics.userservice.application.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+	private List<T> content;
+	private int page;
+	private int size;
+	private long totalElements;
+	private int totalPages;
+
+	public static <T> PageResponse<T> of(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages()
+		);
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/ShipperViewResponseDto.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/ShipperViewResponseDto.java
@@ -1,0 +1,43 @@
+package com.shoonglogitics.userservice.application.dto;
+
+import java.util.UUID;
+
+import com.shoonglogitics.userservice.domain.entity.ShipperType;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ShipperViewResponseDto {
+
+	private Long shipperId;
+	private String name;
+	private String email;
+	private String phoneNumber;
+	private String slackId;
+	private UUID hubId;
+
+	private ShipperType shipperType;
+	private Integer shippingOrder;
+	private Boolean isShippingAvailable;
+
+	public ShipperViewResponseDto(
+		Long shipperId, String name,
+		String email,
+		String phoneNumber,
+		String slackId,
+		UUID hubId, ShipperType shipperType,
+		Integer shippingOrder, Boolean isShippingAvailable) {
+
+		this.shipperId = shipperId;
+		this.name = name;
+		this.email = email;
+		this.phoneNumber = phoneNumber;
+		this.slackId = slackId;
+		this.hubId = hubId;
+		this.shipperType = shipperType;
+		this.shippingOrder = shippingOrder;
+		this.isShippingAvailable = isShippingAvailable;
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/UserResponseDto.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/dto/UserResponseDto.java
@@ -1,0 +1,27 @@
+package com.shoonglogitics.userservice.application.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+public class UserResponseDto {
+
+	private Long userId;
+	private String username;
+	private String role;
+	private String signupStatus;
+
+	@QueryProjection
+	public UserResponseDto(Long userId, String username, String role, String signupStatus) {
+		this.userId = userId;
+		this.username = username;
+		this.role = role;
+		this.signupStatus = signupStatus;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/service/UserService.java
@@ -1,0 +1,38 @@
+package com.shoonglogitics.userservice.application.service;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.application.strategy.SignUpStrategy;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	private final Map<String, SignUpStrategy> signUpStrategyMap;
+
+	@Transactional
+	public void signUp(SignUpUserCommand command) {
+		if (userRepository.findByUsername(command.getUserName()).isPresent()) {
+			throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
+		}
+
+		String typeKey = command.getClass().getSimpleName();
+		SignUpStrategy strategy = signUpStrategyMap.get(typeKey);
+
+		if (strategy == null) {
+			throw new IllegalArgumentException("지원하지 않는 유형입니다.");
+		}
+
+		strategy.signUp(command);
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/service/UserService.java
@@ -1,23 +1,52 @@
 package com.shoonglogitics.userservice.application.service;
 
 import java.util.Map;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
-import com.shoonglogitics.userservice.application.strategy.SignUpStrategy;
+import com.shoonglogitics.userservice.application.dto.PageResponse;
+import com.shoonglogitics.userservice.application.strategy.signup.SignUpStrategy;
+import com.shoonglogitics.userservice.application.strategy.view.CompanyManagerViewStrategy;
+import com.shoonglogitics.userservice.application.strategy.view.HubManagerViewStrategy;
+import com.shoonglogitics.userservice.application.strategy.view.MasterViewStrategy;
+import com.shoonglogitics.userservice.application.strategy.view.ShipperViewStrategy;
+import com.shoonglogitics.userservice.application.strategy.view.UserViewStrategy;
 import com.shoonglogitics.userservice.domain.repository.UserRepository;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class UserService {
 
 	private final UserRepository userRepository;
 
 	private final Map<String, SignUpStrategy> signUpStrategyMap;
+
+	private final Map<String, UserViewStrategy<?>> userViewStrategyMap;
+
+	// 생성자에서 Strategy Map 초기화
+	public UserService(
+		UserRepository userRepository,
+		MasterViewStrategy masterViewStrategy,
+		HubManagerViewStrategy hubManagerViewStrategy,
+		ShipperViewStrategy shipperViewStrategy,
+		CompanyManagerViewStrategy companyManagerViewStrategy,
+		Map<String, SignUpStrategy> signUpStrategyMap
+	) {
+		this.userRepository = userRepository;
+		this.signUpStrategyMap = signUpStrategyMap;
+
+		// Map 구성
+		this.userViewStrategyMap = Map.of(
+			"MASTER", masterViewStrategy,
+			"HUB_MANAGER", hubManagerViewStrategy,
+			"SHIPPER", shipperViewStrategy,
+			"COMPANY_MANAGER", companyManagerViewStrategy
+		);
+	}
 
 	@Transactional
 	public void signUp(SignUpUserCommand command) {
@@ -33,6 +62,18 @@ public class UserService {
 		}
 
 		strategy.signUp(command);
+	}
+
+	@Transactional(readOnly = true)
+	public <T> PageResponse<T> getUsers(String roleKey, Pageable pageable, UUID hubId) {
+		UserViewStrategy<T> strategy = (UserViewStrategy<T>)userViewStrategyMap.get(roleKey);
+
+		if (strategy == null) {
+			throw new IllegalArgumentException("지원하지 않는 역할입니다 : " + roleKey);
+		}
+
+		Page<T> users = strategy.findUsers(pageable, hubId);
+		return PageResponse.of(users);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/CompanyManagerSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/CompanyManagerSignUpStrategy.java
@@ -1,0 +1,41 @@
+package com.shoonglogitics.userservice.application.strategy;
+
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.domain.entity.CompanyManager;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service(value = "CompanyManagerSignUpCommand")
+@RequiredArgsConstructor
+public class CompanyManagerSignUpStrategy implements SignUpStrategy {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public void signUp(SignUpUserCommand signUpUserCommand) {
+		CompanyManagerSignUpCommand command = (CompanyManagerSignUpCommand)signUpUserCommand;
+
+		if (userRepository.findByUsername(command.getUserName()).isPresent()) {
+			throw new IllegalArgumentException("이미 존재하는 COMPANY_MANAGER 회원입니다.");
+		}
+
+		// CompanyManager 생성 (User 상속 포함)
+		CompanyManager companyManager = CompanyManager.create(
+			command.getUserName(),
+			command.getPassword(),
+			command.getCompanyId(),
+			command.getEmail(),
+			command.getName(),
+			command.getSlackId(),
+			command.getPhoneNumber()
+		);
+
+		userRepository.save(companyManager);
+	}
+
+}
+

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/HubManagerSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/HubManagerSignUpStrategy.java
@@ -1,0 +1,41 @@
+package com.shoonglogitics.userservice.application.strategy;
+
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.domain.entity.HubManager;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service(value = "HubManagerSignUpCommand")
+@RequiredArgsConstructor
+public class HubManagerSignUpStrategy implements SignUpStrategy {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public void signUp(SignUpUserCommand signUpUserCommand) {
+		HubManagerSignUpCommand command = (HubManagerSignUpCommand)signUpUserCommand;
+
+		if (userRepository.findByUsername(command.getUserName()).isPresent()) {
+			throw new IllegalArgumentException("이미 존재하는 HUB_MANAGER 회원입니다.");
+		}
+
+		// HubManager 생성
+		HubManager hubManager = HubManager.create(
+			command.getUserName(),
+			command.getPassword(),
+			command.getEmail(),
+			command.getName(),
+			command.getSlackId(),
+			command.getPhoneNumber(),
+			command.getHubId()
+		);
+
+		userRepository.save(hubManager);
+	}
+
+}
+

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/MasterSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/MasterSignUpStrategy.java
@@ -1,0 +1,42 @@
+package com.shoonglogitics.userservice.application.strategy;
+
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.domain.entity.Master;
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service(value = "MasterSignUpCommand")
+@RequiredArgsConstructor
+public class MasterSignUpStrategy implements SignUpStrategy {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public void signUp(SignUpUserCommand signUpUserCommand) {
+		MasterSignUpCommand command = (MasterSignUpCommand)signUpUserCommand;
+
+		if (userRepository.findByUsername(command.getUserName()).isPresent()) {
+			throw new IllegalArgumentException("이미 존재하는 MASTER 회원입니다.");
+		}
+
+		Master master = Master.builder()
+			.userName(command.getUserName())
+			.password(command.getPassword())
+			.userRole(UserRole.MASTER)
+			.signupStatus(SignupStatus.PENDING)
+			.email(command.getEmail())
+			.name(command.getName())
+			.slackId(command.getSlackId())
+			.phoneNumber(command.getPhoneNumber())
+			.build();
+
+		userRepository.save(master);
+	}
+}
+

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/ShipperSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/ShipperSignUpStrategy.java
@@ -1,0 +1,45 @@
+package com.shoonglogitics.userservice.application.strategy;
+
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.domain.entity.Shipper;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service(value = "ShipperSignUpCommand")
+@RequiredArgsConstructor
+public class ShipperSignUpStrategy implements SignUpStrategy {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public void signUp(SignUpUserCommand signUpUserCommand) {
+		ShipperSignUpCommand command = (ShipperSignUpCommand)signUpUserCommand;
+
+		if (userRepository.findByUsername(command.getUserName()).isPresent()) {
+			throw new IllegalArgumentException("이미 존재하는 SHIPPER 회원입니다.");
+		}
+
+		// Shipper 객체를 직접 생성
+		Shipper shipper = Shipper.create(
+			command.getUserName(),
+			command.getPassword(),
+			command.getHubId(),
+			command.getEmail(),
+			command.getName(),
+			command.getSlackId(),
+			command.getPhoneNumber(),
+			command.getShipperType(),
+			command.getOrder(),
+			command.getIsShippingAvailable()
+		);
+
+		userRepository.save(shipper);
+	}
+
+}
+
+

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/SignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/SignUpStrategy.java
@@ -1,0 +1,8 @@
+package com.shoonglogitics.userservice.application.strategy;
+
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+
+public interface SignUpStrategy {
+
+	void signUp(SignUpUserCommand signUpUserCommand);
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/CompanyManagerSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/CompanyManagerSignUpStrategy.java
@@ -1,4 +1,4 @@
-package com.shoonglogitics.userservice.application.strategy;
+package com.shoonglogitics.userservice.application.strategy.signup;
 
 import org.springframework.stereotype.Service;
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/HubManagerSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/HubManagerSignUpStrategy.java
@@ -1,4 +1,4 @@
-package com.shoonglogitics.userservice.application.strategy;
+package com.shoonglogitics.userservice.application.strategy.signup;
 
 import org.springframework.stereotype.Service;
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/MasterSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/MasterSignUpStrategy.java
@@ -1,4 +1,4 @@
-package com.shoonglogitics.userservice.application.strategy;
+package com.shoonglogitics.userservice.application.strategy.signup;
 
 import org.springframework.stereotype.Service;
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/ShipperSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/ShipperSignUpStrategy.java
@@ -1,4 +1,4 @@
-package com.shoonglogitics.userservice.application.strategy;
+package com.shoonglogitics.userservice.application.strategy.signup;
 
 import org.springframework.stereotype.Service;
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/SignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/SignUpStrategy.java
@@ -1,4 +1,4 @@
-package com.shoonglogitics.userservice.application.strategy;
+package com.shoonglogitics.userservice.application.strategy.signup;
 
 import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/CompanyManagerViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/CompanyManagerViewStrategy.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.application.strategy.view;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -20,6 +21,11 @@ public class CompanyManagerViewStrategy implements UserViewStrategy<CompanyManag
 	@Override
 	public Page<CompanyManagerViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
 		return userRepository.findCompanyManagers(pageable);
+	}
+
+	@Override
+	public Optional<CompanyManagerViewResponseDto> findUserById(Long id) {
+		return userRepository.findCompanyManagerById(id);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/CompanyManagerViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/CompanyManagerViewStrategy.java
@@ -1,0 +1,25 @@
+package com.shoonglogitics.userservice.application.strategy.view;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyManagerViewStrategy implements UserViewStrategy<CompanyManagerViewResponseDto> {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public Page<CompanyManagerViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
+		return userRepository.findCompanyManagers(pageable);
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/HubManagerViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/HubManagerViewStrategy.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.application.strategy.view;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -20,6 +21,11 @@ public class HubManagerViewStrategy implements UserViewStrategy<HubManagerViewRe
 	@Override
 	public Page<HubManagerViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
 		return userRepository.findHubManagers(pageable);
+	}
+
+	@Override
+	public Optional<HubManagerViewResponseDto> findUserById(Long id) {
+		return userRepository.findHubManagerById(id);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/HubManagerViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/HubManagerViewStrategy.java
@@ -1,0 +1,25 @@
+package com.shoonglogitics.userservice.application.strategy.view;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HubManagerViewStrategy implements UserViewStrategy<HubManagerViewResponseDto> {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public Page<HubManagerViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
+		return userRepository.findHubManagers(pageable);
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/MasterViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/MasterViewStrategy.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.application.strategy.view;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -20,6 +21,11 @@ public class MasterViewStrategy implements UserViewStrategy<MasterViewResponseDt
 	@Override
 	public Page<MasterViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
 		return userRepository.findMasters(pageable);
+	}
+
+	@Override
+	public Optional<MasterViewResponseDto> findUserById(Long id) {
+		return userRepository.findMasterById(id);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/MasterViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/MasterViewStrategy.java
@@ -1,0 +1,25 @@
+package com.shoonglogitics.userservice.application.strategy.view;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MasterViewStrategy implements UserViewStrategy<MasterViewResponseDto> {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public Page<MasterViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
+		return userRepository.findMasters(pageable);
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/ShipperViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/ShipperViewStrategy.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.application.strategy.view;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -20,6 +21,11 @@ public class ShipperViewStrategy implements UserViewStrategy<ShipperViewResponse
 	@Override
 	public Page<ShipperViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
 		return userRepository.findShippers(hubId, pageable);
+	}
+
+	@Override
+	public Optional<ShipperViewResponseDto> findUserById(Long id) {
+		return userRepository.findShipperById(id);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/ShipperViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/ShipperViewStrategy.java
@@ -1,0 +1,25 @@
+package com.shoonglogitics.userservice.application.strategy.view;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShipperViewStrategy implements UserViewStrategy<ShipperViewResponseDto> {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public Page<ShipperViewResponseDto> findUsers(Pageable pageable, UUID hubId) {
+		return userRepository.findShippers(hubId, pageable);
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/UserViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/UserViewStrategy.java
@@ -1,0 +1,12 @@
+package com.shoonglogitics.userservice.application.strategy.view;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserViewStrategy<T> {
+
+	Page<T> findUsers(Pageable pageable, UUID hubId);
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/UserViewStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/view/UserViewStrategy.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.application.strategy.view;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -8,5 +9,7 @@ import org.springframework.data.domain.Pageable;
 public interface UserViewStrategy<T> {
 
 	Page<T> findUsers(Pageable pageable, UUID hubId);
+
+	Optional<T> findUserById(Long id);
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
@@ -1,0 +1,71 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import com.shoonglogitics.userservice.domain.vo.CompanyId;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_company_manager")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyManager {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	@AttributeOverride(name = "id", column = @Column(name = "company_id"))
+	private CompanyId companyId;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@JoinColumn(name = "p_user_id", nullable = false)
+	private User user;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "email"))
+	private Email email;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "name"))
+	private Name name;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "slack_id"))
+	private SlackId slackId;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
+	private PhoneNumber phoneNumber;
+
+	@Builder
+	public CompanyManager(CompanyId companyId, User user, Email email, Name name,
+		SlackId slackId, PhoneNumber phoneNumber) {
+		this.companyId = companyId;
+		this.user = user;
+		this.email = email;
+		this.name = name;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
@@ -10,9 +10,6 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -25,10 +22,6 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "p_company_manager")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompanyManager extends User {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "company_id"))

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
@@ -7,27 +7,24 @@ import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
 import com.shoonglogitics.userservice.domain.vo.SlackId;
 
 import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
+@SuperBuilder
 @Table(name = "p_company_manager")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CompanyManager {
+public class CompanyManager extends User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,10 +33,6 @@ public class CompanyManager {
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "company_id"))
 	private CompanyId companyId;
-
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-	@JoinColumn(name = "p_user_id", nullable = false)
-	private User user;
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))
@@ -57,15 +50,31 @@ public class CompanyManager {
 	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
 	private PhoneNumber phoneNumber;
 
-	@Builder
-	public CompanyManager(CompanyId companyId, User user, Email email, Name name,
-		SlackId slackId, PhoneNumber phoneNumber) {
-		this.companyId = companyId;
-		this.user = user;
-		this.email = email;
-		this.name = name;
-		this.slackId = slackId;
-		this.phoneNumber = phoneNumber;
+	public static CompanyManager create(String userName, String password, CompanyId companyId,
+		Email email, Name name, SlackId slackId, PhoneNumber phoneNumber) {
+		validateVO(email, name, slackId, phoneNumber);
+		return CompanyManager.builder()
+			.userName(userName)
+			.password(password)
+			.signupStatus(SignupStatus.PENDING)
+			.userRole(UserRole.COMPANY_MANAGER)
+			.companyId(companyId)
+			.email(email)
+			.name(name)
+			.slackId(slackId)
+			.phoneNumber(phoneNumber)
+			.build();
+	}
+
+	private static void validateVO(Email email, Name name, SlackId slackId, PhoneNumber phoneNumber) {
+		if (email == null)
+			throw new IllegalArgumentException("이메일은 필수 값입니다.");
+		if (name == null)
+			throw new IllegalArgumentException("이름은 필수 값입니다.");
+		if (slackId == null)
+			throw new IllegalArgumentException("Slack ID는 필수 값입니다.");
+		if (phoneNumber == null)
+			throw new IllegalArgumentException("전화번호는 필수 값입니다.");
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
@@ -7,27 +7,24 @@ import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
 import com.shoonglogitics.userservice.domain.vo.SlackId;
 
 import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
 @Table(name = "p_hub_manager")
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class HubManager {
+public class HubManager extends User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,9 +34,9 @@ public class HubManager {
 	@AttributeOverride(name = "id", column = @Column(name = "hub_id"))
 	private HubId hubId;
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	/*@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "p_user_id", nullable = false)
-	private User user;
+	private User user;*/
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))
@@ -57,15 +54,43 @@ public class HubManager {
 	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
 	private PhoneNumber phoneNumber;
 
-	@Builder
-	public HubManager(HubId hubId, User user, Email email, Name name,
-		SlackId slackId, PhoneNumber phoneNumber) {
-		this.hubId = hubId;
-		this.user = user;
+	public HubManager(String userName, String password,
+		Email email, Name name, SlackId slackId,
+		PhoneNumber phoneNumber, HubId hubId) {
+		super(userName, password, UserRole.HUB_MANAGER, SignupStatus.PENDING);
 		this.email = email;
 		this.name = name;
 		this.slackId = slackId;
 		this.phoneNumber = phoneNumber;
+		this.hubId = hubId;
 	}
 
+	// 정적 팩토리 메서드
+	public static HubManager create(String userName, String password,
+		Email email, Name name, SlackId slackId,
+		PhoneNumber phoneNumber, HubId hubId) {
+		validateVO(email, name, slackId, phoneNumber);
+		return HubManager.builder()
+			.userName(userName)
+			.password(password)
+			.signupStatus(SignupStatus.PENDING)
+			.userRole(UserRole.HUB_MANAGER)
+			.hubId(hubId)
+			.email(email)
+			.name(name)
+			.slackId(slackId)
+			.phoneNumber(phoneNumber)
+			.build();
+	}
+
+	private static void validateVO(Email email, Name name, SlackId slackId, PhoneNumber phoneNumber) {
+		if (email == null)
+			throw new IllegalArgumentException("이메일은 필수 값입니다.");
+		if (name == null)
+			throw new IllegalArgumentException("이름은 필수 값입니다.");
+		if (slackId == null)
+			throw new IllegalArgumentException("Slack ID는 필수 값입니다.");
+		if (phoneNumber == null)
+			throw new IllegalArgumentException("전화번호는 필수 값입니다.");
+	}
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
@@ -10,9 +10,6 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,17 +23,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HubManager extends User {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "hub_id"))
 	private HubId hubId;
-
-	/*@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "p_user_id", nullable = false)
-	private User user;*/
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
@@ -1,0 +1,71 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_hub_manager")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubManager {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	@AttributeOverride(name = "id", column = @Column(name = "hub_id"))
+	private HubId hubId;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@JoinColumn(name = "p_user_id", nullable = false)
+	private User user;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "email"))
+	private Email email;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "name"))
+	private Name name;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "slack_id"))
+	private SlackId slackId;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
+	private PhoneNumber phoneNumber;
+
+	@Builder
+	public HubManager(HubId hubId, User user, Email email, Name name,
+		SlackId slackId, PhoneNumber phoneNumber) {
+		this.hubId = hubId;
+		this.user = user;
+		this.email = email;
+		this.name = name;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
@@ -9,9 +9,6 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,10 +21,6 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Master extends User {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
@@ -1,0 +1,64 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_master")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Master {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@JoinColumn(name = "p_user_id", nullable = false)
+	private User user;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "email"))
+	private Email email;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "name"))
+	private Name name;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "slack_id"))
+	private SlackId slackId;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
+	private PhoneNumber phoneNumber;
+
+	@Builder
+	public Master(User user, Email email, Name name, SlackId slackId, PhoneNumber phoneNumber) {
+		this.user = user;
+		this.email = email;
+		this.name = name;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
@@ -6,35 +6,28 @@ import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
 import com.shoonglogitics.userservice.domain.vo.SlackId;
 
 import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
 @Table(name = "p_master")
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Master {
+public class Master extends User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-	@JoinColumn(name = "p_user_id", nullable = false)
-	private User user;
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))
@@ -52,13 +45,35 @@ public class Master {
 	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
 	private PhoneNumber phoneNumber;
 
-	@Builder
-	public Master(User user, Email email, Name name, SlackId slackId, PhoneNumber phoneNumber) {
-		this.user = user;
-		this.email = email;
-		this.name = name;
-		this.slackId = slackId;
-		this.phoneNumber = phoneNumber;
+	public static Master create(String userName, String password, Email email, Name name,
+		SlackId slackId, PhoneNumber phoneNumber) {
+		validateVO(email, name, slackId, phoneNumber);
+
+		return Master.builder()
+			.userName(userName)
+			.password(password)
+			.signupStatus(SignupStatus.PENDING)
+			.userRole(UserRole.MASTER)
+			.email(email)
+			.name(name)
+			.slackId(slackId)
+			.phoneNumber(phoneNumber)
+			.build();
+	}
+
+	private static void validateVO(Email email, Name name, SlackId slackId, PhoneNumber phoneNumber) {
+		if (email == null) {
+			throw new IllegalArgumentException("이메일은 필수 값입니다.");
+		}
+		if (name == null) {
+			throw new IllegalArgumentException("이름은 필수 값입니다.");
+		}
+		if (slackId == null) {
+			throw new IllegalArgumentException("Slack ID는 필수 값입니다.");
+		}
+		if (phoneNumber == null) {
+			throw new IllegalArgumentException("전화번호는 필수 값입니다.");
+		}
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
@@ -1,0 +1,91 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_shipper")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Shipper {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	@AttributeOverride(name = "id", column = @Column(name = "hub_id", nullable = true))
+	private HubId hubId;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@JoinColumn(name = "p_user_id", nullable = false)
+	private User user;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "email"))
+	private Email email;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "name"))
+	private Name name;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "slack_id"))
+	private SlackId slackId;
+
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "phone_number"))
+	private PhoneNumber phoneNumber;
+
+	@Enumerated(EnumType.STRING)
+	@JdbcTypeCode(SqlTypes.NAMED_ENUM)
+	@Column(name = "shipper_type", nullable = false)
+	private ShipperType shipperType;
+
+	@Column(name = "order", nullable = false)
+	private Integer order;
+
+	@Column(name = "is_shipping_available", nullable = false)
+	private Boolean isShippingAvailable;
+
+	@Builder
+	public Shipper(HubId hubId, User user, Email email, Name name, SlackId slackId,
+		PhoneNumber phoneNumber, ShipperType shipperType,
+		Integer order, Boolean isShippingAvailable) {
+		this.hubId = hubId;
+		this.user = user;
+		this.email = email;
+		this.name = name;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
+		this.shipperType = shipperType;
+		this.order = order;
+		this.isShippingAvailable = isShippingAvailable;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
@@ -13,9 +13,6 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,17 +27,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Shipper extends User {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "hub_id", nullable = true))
 	private HubId hubId;
-
-	/*@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "p_user_id", nullable = false)
-	private User user;*/
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
@@ -1,8 +1,5 @@
 package com.shoonglogitics.userservice.domain.entity;
 
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
 import com.shoonglogitics.userservice.domain.vo.Email;
 import com.shoonglogitics.userservice.domain.vo.HubId;
 import com.shoonglogitics.userservice.domain.vo.Name;
@@ -10,29 +7,28 @@ import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
 import com.shoonglogitics.userservice.domain.vo.SlackId;
 
 import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
+@DiscriminatorValue("SHIPPER")
 @Table(name = "p_shipper")
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Shipper {
+public class Shipper extends User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,9 +38,9 @@ public class Shipper {
 	@AttributeOverride(name = "id", column = @Column(name = "hub_id", nullable = true))
 	private HubId hubId;
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	/*@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "p_user_id", nullable = false)
-	private User user;
+	private User user;*/
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))
@@ -63,29 +59,41 @@ public class Shipper {
 	private PhoneNumber phoneNumber;
 
 	@Enumerated(EnumType.STRING)
-	@JdbcTypeCode(SqlTypes.NAMED_ENUM)
 	@Column(name = "shipper_type", nullable = false)
 	private ShipperType shipperType;
 
-	@Column(name = "order", nullable = false)
+	@Column(name = "shipping_order", nullable = false)
 	private Integer order;
 
 	@Column(name = "is_shipping_available", nullable = false)
 	private Boolean isShippingAvailable;
 
-	@Builder
-	public Shipper(HubId hubId, User user, Email email, Name name, SlackId slackId,
-		PhoneNumber phoneNumber, ShipperType shipperType,
+	public static Shipper create(String userName, String password, HubId hubId, Email email, Name name,
+		SlackId slackId, PhoneNumber phoneNumber, ShipperType shipperType,
 		Integer order, Boolean isShippingAvailable) {
-		this.hubId = hubId;
-		this.user = user;
-		this.email = email;
-		this.name = name;
-		this.slackId = slackId;
-		this.phoneNumber = phoneNumber;
-		this.shipperType = shipperType;
-		this.order = order;
-		this.isShippingAvailable = isShippingAvailable;
+
+		// shipperType 검증
+		if (shipperType == ShipperType.COMPANY_SHIPPER && hubId == null) {
+			throw new IllegalArgumentException("업체 배송 담당자는 허브 ID가 반드시 필요합니다.");
+		}
+		if (shipperType == ShipperType.HUB_SHIPPER && hubId != null) {
+			throw new IllegalArgumentException("허브 배송 담당자는 허브 ID가 없어야 합니다.");
+		}
+
+		return Shipper.builder()
+			.userName(userName)
+			.password(password)
+			.userRole(UserRole.SHIPPER)
+			.signupStatus(SignupStatus.PENDING)
+			.hubId(hubId)
+			.email(email)
+			.name(name)
+			.slackId(slackId)
+			.phoneNumber(phoneNumber)
+			.shipperType(shipperType)
+			.order(order)
+			.isShippingAvailable(isShippingAvailable)
+			.build();
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/ShipperType.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/ShipperType.java
@@ -1,0 +1,9 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ShipperType {
+	HUB_SHIPPER, // 허브 배송 담당자
+	COMPANY_SHIPPER; // 업체 배송 담당자
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/SignupStatus.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/SignupStatus.java
@@ -1,0 +1,10 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum SignupStatus {
+	PENDING, // 승인 대기 상태
+	APPROVED, // 승인 상태
+	REJECTED; // 거절 상태
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
@@ -73,4 +73,20 @@ public class User {
 		}
 	}
 
+	public void approveSignup() {
+		if (this.signupStatus != SignupStatus.PENDING) {
+			throw new IllegalArgumentException("승인할 수 없는 상태입니다.");
+		}
+		this.signupStatus = SignupStatus.APPROVED;
+
+	}
+
+	public void rejectSignup() {
+		if (this.signupStatus != SignupStatus.PENDING) {
+			throw new IllegalArgumentException("승인할 수 없는 상태입니다.");
+		}
+		this.signupStatus = SignupStatus.REJECTED;
+
+	}
+
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
@@ -1,9 +1,5 @@
 package com.shoonglogitics.userservice.domain.entity;
 
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-import org.springframework.data.domain.AbstractAggregateRoot;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,17 +7,21 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "p_user")
 @Getter
+@Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends AbstractAggregateRoot<User> {
+@SuperBuilder
+public class User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,21 +34,43 @@ public class User extends AbstractAggregateRoot<User> {
 	private String password;
 
 	@Enumerated(EnumType.STRING)
-	@JdbcTypeCode(SqlTypes.NAMED_ENUM)
 	@Column(name = "user_role", nullable = false)
 	private UserRole userRole;
 
 	@Enumerated(EnumType.STRING)
-	@JdbcTypeCode(SqlTypes.NAMED_ENUM)
 	@Column(name = "signup_status", nullable = false)
 	private SignupStatus signupStatus;
 
-	@Builder
-	public User(String userName, String password, UserRole userRole, SignupStatus signupStatus) {
+	protected User(String userName, String password, UserRole userRole, SignupStatus signupStatus) {
 		this.userName = userName;
 		this.password = password;
 		this.userRole = userRole;
 		this.signupStatus = signupStatus;
+	}
+
+	public static User create(String userName, String password, UserRole userRole) {
+		validateUserName(userName);
+		validatePassword(password);
+
+		return new User(userName, password, userRole, SignupStatus.PENDING);
+	}
+
+	private static void validateUserName(String userName) {
+		if (userName == null || userName.isEmpty()) {
+			throw new IllegalArgumentException("아이디 값은 필수입니다.");
+		}
+		if (userName.length() < 4 || userName.length() > 10) {
+			throw new IllegalArgumentException("아이디는 4자 이상 10자 이하이어야 합니다.");
+		}
+	}
+
+	private static void validatePassword(String password) {
+		if (password == null || password.isEmpty()) {
+			throw new IllegalArgumentException("비밀번호 값은 필수입니다.");
+		}
+		if (password.length() < 8 || password.length() > 15) {
+			throw new IllegalArgumentException("비밀번호는 8자 이상 15자 이하이어야 합니다.");
+		}
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
@@ -1,0 +1,54 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.domain.AbstractAggregateRoot;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends AbstractAggregateRoot<User> {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_name", nullable = false, unique = true, length = 10)
+	private String userName;
+
+	@Column(name = "password", nullable = false, length = 15)
+	private String password;
+
+	@Enumerated(EnumType.STRING)
+	@JdbcTypeCode(SqlTypes.NAMED_ENUM)
+	@Column(name = "user_role", nullable = false)
+	private UserRole userRole;
+
+	@Enumerated(EnumType.STRING)
+	@JdbcTypeCode(SqlTypes.NAMED_ENUM)
+	@Column(name = "signup_status", nullable = false)
+	private SignupStatus signupStatus;
+
+	@Builder
+	public User(String userName, String password, UserRole userRole, SignupStatus signupStatus) {
+		this.userName = userName;
+		this.password = password;
+		this.userRole = userRole;
+		this.signupStatus = signupStatus;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/UserRole.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/UserRole.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+	MASTER(Authority.MASTER),
+	HUB_MANAGER(Authority.HUB_MANAGER),
+	COMPANY_MANAGER(Authority.COMPANY_MANAGER),
+	SHIPPER(Authority.SHIPPER);
+
+	private final String authority;
+
+	UserRole(String authority) {
+		this.authority = authority;
+	}
+
+	public static class Authority {
+		public static final String MASTER = "ROLE_MASTER";
+		public static final String HUB_MANAGER = "ROLE_HUB_MANAGER";
+		public static final String COMPANY_MANAGER = "ROLE_COMPANY_MANAGER";
+		public static final String SHIPPER = "ROLE_SHIPPER";
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository {
 	// TODO : AndDeletedAtIsNull도 추가하기
 	Optional<User> findByUsername(String username);
 
+	User save(User user);
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
@@ -19,6 +19,8 @@ public interface UserRepository {
 
 	User save(User user);
 
+	Optional<User> findById(Long id);
+
 	Page<MasterViewResponseDto> findMasters(Pageable pageable);
 
 	Page<HubManagerViewResponseDto> findHubManagers(Pageable pageable);
@@ -26,4 +28,12 @@ public interface UserRepository {
 	Page<ShipperViewResponseDto> findShippers(UUID hubId, Pageable pageable);
 
 	Page<CompanyManagerViewResponseDto> findCompanyManagers(Pageable pageable);
+
+	Optional<MasterViewResponseDto> findMasterById(Long id);
+
+	Optional<HubManagerViewResponseDto> findHubManagerById(Long id);
+
+	Optional<ShipperViewResponseDto> findShipperById(Long id);
+
+	Optional<CompanyManagerViewResponseDto> findCompanyManagerById(Long id);
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
@@ -1,4 +1,12 @@
 package com.shoonglogitics.userservice.domain.repository;
 
+import java.util.Optional;
+
+import com.shoonglogitics.userservice.domain.entity.User;
+
 public interface UserRepository {
+
+	// TODO : AndDeletedAtIsNull도 추가하기
+	Optional<User> findByUsername(String username);
+
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package com.shoonglogitics.userservice.domain.repository;
+
+public interface UserRepository {
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
@@ -1,7 +1,15 @@
 package com.shoonglogitics.userservice.domain.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
 import com.shoonglogitics.userservice.domain.entity.User;
 
 public interface UserRepository {
@@ -10,4 +18,12 @@ public interface UserRepository {
 	Optional<User> findByUsername(String username);
 
 	User save(User user);
+
+	Page<MasterViewResponseDto> findMasters(Pageable pageable);
+
+	Page<HubManagerViewResponseDto> findHubManagers(Pageable pageable);
+
+	Page<ShipperViewResponseDto> findShippers(UUID hubId, Pageable pageable);
+
+	Page<CompanyManagerViewResponseDto> findCompanyManagers(Pageable pageable);
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/CompanyId.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/CompanyId.java
@@ -1,0 +1,26 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import java.util.UUID;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyId {
+
+	private UUID id;
+
+	public CompanyId(UUID id) {
+		if (id == null) {
+			throw new IllegalArgumentException("업체의 id가 필요합니다.");
+		}
+		this.id = id;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/Email.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/Email.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Email {
+
+	private String value;
+
+	public Email(String value) {
+		if (value == null || value.isEmpty()) {
+			throw new IllegalArgumentException("이메일은 필수값입니다.");
+		}
+		this.value = value;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/HubId.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/HubId.java
@@ -1,0 +1,26 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import java.util.UUID;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubId {
+
+	private UUID id;
+
+	public HubId(UUID id) {
+		if (id == null) {
+			throw new IllegalArgumentException("허브의 id가 필요합니다.");
+		}
+		this.id = id;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/Name.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/Name.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Name {
+
+	private String value;
+
+	public Name(String value) {
+		if (value == null || value.isEmpty()) {
+			throw new IllegalArgumentException("이름정보는 필수값입니다.");
+		}
+		this.value = value;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/PhoneNumber.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/PhoneNumber.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhoneNumber {
+
+	private String value;
+
+	public PhoneNumber(String value) {
+		if (value == null || value.isEmpty()) {
+			throw new IllegalArgumentException("Slakc 정보는 필수값입니다.");
+		}
+		this.value = value;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/SlackId.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/SlackId.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SlackId {
+
+	private String value;
+
+	public SlackId(String value) {
+		if (value == null || value.isEmpty()) {
+			throw new IllegalArgumentException("Slakc 정보는 필수값입니다.");
+		}
+		this.value = value;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/UserId.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/vo/UserId.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.userservice.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserId {
+
+	private Long id;
+
+	public UserId(Long id) {
+		if(id == null){
+			throw new IllegalArgumentException("인증된 회원 식별자 id가 필요합니다.");
+		}
+		this.id = id;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/config/RedisConfig.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.shoonglogitics.userservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		return new StringRedisTemplate(redisConnectionFactory);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
@@ -1,0 +1,10 @@
+package com.shoonglogitics.userservice.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.shoonglogitics.userservice.domain.entity.User;
+
+@Repository
+public interface JpaUserRepository extends JpaRepository<User, Long> {
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto;
@@ -85,5 +86,58 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 		    from CompanyManager c
 		""")
 	Page<CompanyManagerViewResponseDto> findCompanyManagers(Pageable pageable);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.MasterViewResponseDto(
+		        m.id,
+		        m.name.value,
+		        m.email.value,
+		        m.phoneNumber.value,
+		        m.slackId.value
+		    )
+		    from Master m
+		    where m.id = :id
+		""")
+	Optional<MasterViewResponseDto> findMasterById(@Param("id") Long id);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto(
+		        h.id,
+		        h.name.value,
+		        h.email.value,
+		        h.phoneNumber.value,
+		        h.slackId.value,
+		        h.hubId.id
+		    )
+		    from HubManager h
+				    where h.id = :id
+		""")
+	Optional<HubManagerViewResponseDto> findHubManagerById(@Param("id") Long id);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto(
+		        s.id,
+		        s.name.value,
+		        s.email.value,
+		        s.slackId.value,
+		        s.phoneNumber.value,
+		        s.hubId.id, s.shipperType, s.order, s.isShippingAvailable
+		    )
+		    from Shipper s where s.id = :id
+		""")
+	Optional<ShipperViewResponseDto> findShipperById(@Param("id") Long id);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto(
+		        c.id,
+		        c.name.value,
+		        c.email.value,
+		        c.slackId.value,
+		        c.phoneNumber.value,
+		        c.companyId.id
+		    )
+		    from CompanyManager c where c.id = :id
+		""")
+	Optional<CompanyManagerViewResponseDto> findCompanyManagerById(@Param("id") Long id);
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
@@ -1,5 +1,7 @@
 package com.shoonglogitics.userservice.infrastructure.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,8 @@ import com.shoonglogitics.userservice.domain.entity.User;
 
 @Repository
 public interface JpaUserRepository extends JpaRepository<User, Long> {
+
+	// TODO : AndDeletedAtIsNull도 추가하기
+	Optional<User> findByUserName(String userName);
+
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
@@ -1,10 +1,18 @@
 package com.shoonglogitics.userservice.infrastructure.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
 import com.shoonglogitics.userservice.domain.entity.User;
 
 @Repository
@@ -12,5 +20,70 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 
 	// TODO : AndDeletedAtIsNull도 추가하기
 	Optional<User> findByUserName(String userName);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.MasterViewResponseDto(
+		        m.id,
+		        m.name.value,
+		        m.email.value,
+		        m.phoneNumber.value,
+		        m.slackId.value
+		    )
+		    from Master m
+		""")
+	Page<MasterViewResponseDto> findMasters(Pageable pageable);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto(
+		        h.id,
+		        h.name.value,
+		        h.email.value,
+		        h.phoneNumber.value,
+		        h.slackId.value,
+		        h.hubId.id
+		    )
+		    from HubManager h
+		""")
+	Page<HubManagerViewResponseDto> findHubManagers(Pageable pageable);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto(
+		        s.id,
+		        s.name.value,
+		        s.email.value,
+		        s.slackId.value,
+		        s.phoneNumber.value,
+		        s.hubId.id, s.shipperType, s.order, s.isShippingAvailable
+		    )
+		    from Shipper s
+		    where s.hubId.id = :hubId
+		""")
+	Page<ShipperViewResponseDto> findShippersByHubId(UUID hubId, Pageable pageable);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto(
+		        s.id,
+		        s.name.value,
+		        s.email.value,
+		        s.slackId.value,
+		        s.phoneNumber.value,
+		        s.hubId.id, s.shipperType, s.order, s.isShippingAvailable
+		    )
+		    from Shipper s
+		""")
+	Page<ShipperViewResponseDto> findAllShippers(Pageable pageable);
+
+	@Query("""
+		    select new com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto(
+		        c.id,
+		        c.name.value,
+		        c.email.value,
+		        c.slackId.value,
+		        c.phoneNumber.value,
+		        c.companyId.id
+		    )
+		    from CompanyManager c
+		""")
+	Page<CompanyManagerViewResponseDto> findCompanyManagers(Pageable pageable);
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -1,0 +1,15 @@
+package com.shoonglogitics.userservice.infrastructure.repository;
+
+import org.springframework.stereotype.Component;
+
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepository {
+
+	private final JpaUserRepository jpaUserRepository;
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -19,4 +19,9 @@ public class UserRepositoryAdapter implements UserRepository {
 	public Optional<User> findByUsername(String username) {
 		return jpaUserRepository.findByUserName(username);
 	}
+
+	@Override
+	public User save(User user) {
+		return jpaUserRepository.save(user);
+	}
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -33,6 +33,11 @@ public class UserRepositoryAdapter implements UserRepository {
 	}
 
 	@Override
+	public Optional<User> findById(Long id) {
+		return jpaUserRepository.findById(id);
+	}
+
+	@Override
 	public Page<MasterViewResponseDto> findMasters(Pageable pageable) {
 		return jpaUserRepository.findMasters(pageable);
 	}
@@ -54,6 +59,26 @@ public class UserRepositoryAdapter implements UserRepository {
 	@Override
 	public Page<CompanyManagerViewResponseDto> findCompanyManagers(Pageable pageable) {
 		return jpaUserRepository.findCompanyManagers(pageable);
+	}
+
+	@Override
+	public Optional<MasterViewResponseDto> findMasterById(Long id) {
+		return jpaUserRepository.findMasterById(id);
+	}
+
+	@Override
+	public Optional<HubManagerViewResponseDto> findHubManagerById(Long id) {
+		return jpaUserRepository.findHubManagerById(id);
+	}
+
+	@Override
+	public Optional<ShipperViewResponseDto> findShipperById(Long id) {
+		return jpaUserRepository.findShipperById(id);
+	}
+
+	@Override
+	public Optional<CompanyManagerViewResponseDto> findCompanyManagerById(Long id) {
+		return jpaUserRepository.findCompanyManagerById(id);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -1,9 +1,16 @@
 package com.shoonglogitics.userservice.infrastructure.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
+import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
 import com.shoonglogitics.userservice.domain.entity.User;
 import com.shoonglogitics.userservice.domain.repository.UserRepository;
 
@@ -24,4 +31,29 @@ public class UserRepositoryAdapter implements UserRepository {
 	public User save(User user) {
 		return jpaUserRepository.save(user);
 	}
+
+	@Override
+	public Page<MasterViewResponseDto> findMasters(Pageable pageable) {
+		return jpaUserRepository.findMasters(pageable);
+	}
+
+	@Override
+	public Page<HubManagerViewResponseDto> findHubManagers(Pageable pageable) {
+		return jpaUserRepository.findHubManagers(pageable);
+	}
+
+	@Override
+	public Page<ShipperViewResponseDto> findShippers(UUID hubId, Pageable pageable) {
+		if (hubId != null) {
+			return jpaUserRepository.findShippersByHubId(hubId, pageable);
+		} else {
+			return jpaUserRepository.findAllShippers(pageable);
+		}
+	}
+
+	@Override
+	public Page<CompanyManagerViewResponseDto> findCompanyManagers(Pageable pageable) {
+		return jpaUserRepository.findCompanyManagers(pageable);
+	}
+
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -1,7 +1,10 @@
 package com.shoonglogitics.userservice.infrastructure.repository;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
+import com.shoonglogitics.userservice.domain.entity.User;
 import com.shoonglogitics.userservice.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -12,4 +15,8 @@ public class UserRepositoryAdapter implements UserRepository {
 
 	private final JpaUserRepository jpaUserRepository;
 
+	@Override
+	public Optional<User> findByUsername(String username) {
+		return jpaUserRepository.findByUserName(username);
+	}
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -39,61 +39,6 @@ public class UserController {
 	public ResponseEntity<ApiResponse<SignUpResponse>> createUser(@RequestBody SignUpRequest request) {
 		SignUpUserCommand command;
 
-		/*switch (request.getUserType()) {
-			case "MASTER":
-				command = MasterSignUpCommand.builder()
-					.userName(request.getUserName())
-					.password(request.getPassword())
-					.email(new Email(request.getEmail()))
-					.name(new Name(request.getName()))
-					.slackId(new SlackId(request.getSlackId()))
-					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
-					.build();
-				break;
-
-			case "HUB_MANAGER":
-				command = HubManagerSignUpCommand.builder()
-					.userName(request.getUserName())
-					.password(request.getPassword())
-					.email(new Email(request.getEmail()))
-					.name(new Name(request.getName()))
-					.slackId(new SlackId(request.getSlackId()))
-					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
-					.hubId(new HubId(request.getHubId()))
-					.build();
-				break;
-
-			case "COMPANY_MANAGER":
-				command = CompanyManagerSignUpCommand.builder()
-					.userName(request.getUserName())
-					.password(request.getPassword())
-					.email(new Email(request.getEmail()))
-					.name(new Name(request.getName()))
-					.slackId(new SlackId(request.getSlackId()))
-					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
-					.companyId(new CompanyId(request.getCompanyId()))
-					.build();
-				break;
-
-			case "SHIPPER":
-				command = ShipperSignUpCommand.builder()
-					.userName(request.getUserName())
-					.password(request.getPassword())
-					.email(new Email(request.getEmail()))
-					.name(new Name(request.getName()))
-					.slackId(new SlackId(request.getSlackId()))
-					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
-					.hubId(request.getHubId() != null ? new HubId(request.getHubId()) : null)
-					.shipperType(ShipperType.valueOf(request.getShipperType()))
-					.order(request.getOrder())
-					.isShippingAvailable(request.getIsShippingAvailable())
-					.build();
-				break;
-
-			default:
-				throw new IllegalArgumentException("지원하지 않는 회원 유형입니다.");
-		}*/
-
 		userService.signUp(request.toCommand());
 
 		SignUpResponse response = SignUpResponse.builder()

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.presentation.controller;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
@@ -7,28 +8,21 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
-import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
-import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
-import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
 import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
 import com.shoonglogitics.userservice.application.dto.PageResponse;
 import com.shoonglogitics.userservice.application.service.UserService;
-import com.shoonglogitics.userservice.domain.entity.ShipperType;
-import com.shoonglogitics.userservice.domain.vo.CompanyId;
-import com.shoonglogitics.userservice.domain.vo.Email;
-import com.shoonglogitics.userservice.domain.vo.HubId;
-import com.shoonglogitics.userservice.domain.vo.Name;
-import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
-import com.shoonglogitics.userservice.domain.vo.SlackId;
+import com.shoonglogitics.userservice.domain.entity.User;
 import com.shoonglogitics.userservice.presentation.dto.ApiResponse;
 import com.shoonglogitics.userservice.presentation.dto.request.SignUpRequest;
+import com.shoonglogitics.userservice.presentation.dto.request.UpdateSignupStatusRequest;
 import com.shoonglogitics.userservice.presentation.dto.response.SignUpResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -40,11 +34,12 @@ public class UserController {
 
 	private final UserService userService;
 
+	// 회원가입
 	@PostMapping("/signup")
 	public ResponseEntity<ApiResponse<SignUpResponse>> createUser(@RequestBody SignUpRequest request) {
 		SignUpUserCommand command;
 
-		switch (request.getUserType()) {
+		/*switch (request.getUserType()) {
 			case "MASTER":
 				command = MasterSignUpCommand.builder()
 					.userName(request.getUserName())
@@ -97,24 +92,45 @@ public class UserController {
 
 			default:
 				throw new IllegalArgumentException("지원하지 않는 회원 유형입니다.");
-		}
+		}*/
 
-		userService.signUp(command);
+		userService.signUp(request.toCommand());
 
 		SignUpResponse response = SignUpResponse.builder()
 			.userName(request.getUserName())
-			.userType(request.getUserType())
+			.userType(request.getClass().getSimpleName().replace("SignUpRequest", "").toUpperCase())
 			.status("PENDING")
 			.build();
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
 	}
 
+	// 회원 목록 조회
 	@GetMapping
 	public PageResponse<?> getUsers(@RequestParam String role,
 		@RequestParam(required = false) UUID hubId,
 		@PageableDefault(size = 10) Pageable pageable) {
 		return userService.getUsers(role, pageable, hubId);
+	}
+
+	// 회원 단건 조회
+	@GetMapping("/{role}/{id}")
+	public ResponseEntity<?> getUser(@PathVariable String role, @PathVariable Long id) {
+		Optional<?> user = userService.getUser(role, id);
+		return user.map(ResponseEntity::ok)
+			.orElseGet(() -> ResponseEntity.notFound().build());
+	}
+
+	// 회원가입 승인/거절
+	@PutMapping("/{id}/signup-status")
+	//@PreAuthorize("hasAnyRole('HUB_MANAGER', 'MASTER')")
+	public ResponseEntity<Void> updateSignupStatus(@PathVariable Long id,
+		@RequestBody UpdateSignupStatusRequest request) {
+		userService.updateSignupStatus(id, request.getStatus());
+
+		User user = userService.findUser(id);
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -1,0 +1,106 @@
+package com.shoonglogitics.userservice.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
+import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
+import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.application.service.UserService;
+import com.shoonglogitics.userservice.domain.entity.ShipperType;
+import com.shoonglogitics.userservice.domain.vo.CompanyId;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+import com.shoonglogitics.userservice.presentation.dto.ApiResponse;
+import com.shoonglogitics.userservice.presentation.dto.request.SignUpRequest;
+import com.shoonglogitics.userservice.presentation.dto.response.SignUpResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<SignUpResponse>> createUser(@RequestBody SignUpRequest request) {
+		SignUpUserCommand command;
+
+		switch (request.getUserType()) {
+			case "MASTER":
+				command = MasterSignUpCommand.builder()
+					.userName(request.getUserName())
+					.password(request.getPassword())
+					.email(new Email(request.getEmail()))
+					.name(new Name(request.getName()))
+					.slackId(new SlackId(request.getSlackId()))
+					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
+					.build();
+				break;
+
+			case "HUB_MANAGER":
+				command = HubManagerSignUpCommand.builder()
+					.userName(request.getUserName())
+					.password(request.getPassword())
+					.email(new Email(request.getEmail()))
+					.name(new Name(request.getName()))
+					.slackId(new SlackId(request.getSlackId()))
+					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
+					.hubId(new HubId(request.getHubId()))
+					.build();
+				break;
+
+			case "COMPANY_MANAGER":
+				command = CompanyManagerSignUpCommand.builder()
+					.userName(request.getUserName())
+					.password(request.getPassword())
+					.email(new Email(request.getEmail()))
+					.name(new Name(request.getName()))
+					.slackId(new SlackId(request.getSlackId()))
+					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
+					.companyId(new CompanyId(request.getCompanyId()))
+					.build();
+				break;
+
+			case "SHIPPER":
+				command = ShipperSignUpCommand.builder()
+					.userName(request.getUserName())
+					.password(request.getPassword())
+					.email(new Email(request.getEmail()))
+					.name(new Name(request.getName()))
+					.slackId(new SlackId(request.getSlackId()))
+					.phoneNumber(new PhoneNumber(request.getPhoneNumber()))
+					.hubId(request.getHubId() != null ? new HubId(request.getHubId()) : null)
+					.shipperType(ShipperType.valueOf(request.getShipperType()))
+					.order(request.getOrder())
+					.isShippingAvailable(request.getIsShippingAvailable())
+					.build();
+				break;
+
+			default:
+				throw new IllegalArgumentException("지원하지 않는 회원 유형입니다.");
+		}
+
+		userService.signUp(command);
+
+		SignUpResponse response = SignUpResponse.builder()
+			.userName(request.getUserName())
+			.userType(request.getUserType())
+			.status("PENDING")
+			.build();
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -1,10 +1,16 @@
 package com.shoonglogitics.userservice.presentation.controller;
 
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
@@ -12,6 +18,7 @@ import com.shoonglogitics.userservice.application.command.HubManagerSignUpComman
 import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
 import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
 import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
+import com.shoonglogitics.userservice.application.dto.PageResponse;
 import com.shoonglogitics.userservice.application.service.UserService;
 import com.shoonglogitics.userservice.domain.entity.ShipperType;
 import com.shoonglogitics.userservice.domain.vo.CompanyId;
@@ -101,6 +108,13 @@ public class UserController {
 			.build();
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	@GetMapping
+	public PageResponse<?> getUsers(@RequestParam String role,
+		@RequestParam(required = false) UUID hubId,
+		@PageableDefault(size = 10) Pageable pageable) {
+		return userService.getUsers(role, pageable, hubId);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/ApiResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.shoonglogitics.userservice.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+	boolean success,
+	String message,
+	T data,
+	Long timestamp
+) {
+	/**
+	 * 성공 응답 생성 (데이터 포함)
+	 */
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, null, data, System.currentTimeMillis());
+	}
+
+	/**
+	 * 성공 응답 생성 (데이터 + 메시지)
+	 */
+	public static <T> ApiResponse<T> success(T data, String message) {
+		return new ApiResponse<>(true, message, data, System.currentTimeMillis());
+	}
+
+	/**
+	 * 성공 응답 생성 (메시지만)
+	 */
+	public static <T> ApiResponse<T> success(String message) {
+		return new ApiResponse<>(true, message, null, System.currentTimeMillis());
+	}
+
+	/**
+	 * 실패 응답 생성 (에러 데이터)
+	 */
+	public static <T> ApiResponse<T> error(T errorData) {
+		return new ApiResponse<>(false, null, errorData, System.currentTimeMillis());
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/CompanayManagerSignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/CompanayManagerSignUpRequest.java
@@ -1,0 +1,30 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
+import com.shoonglogitics.userservice.domain.vo.CompanyId;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CompanayManagerSignUpRequest extends SignUpRequest {
+	private CompanyId companyId;
+
+	@Override
+	public Object toCommand() {
+		return CompanyManagerSignUpCommand.builder()
+			.userName(getUserName())
+			.password(getPassword())
+			.email(new Email(getEmail()))
+			.name(new Name(getName()))
+			.slackId(new SlackId(getSlackId()))
+			.phoneNumber(new PhoneNumber(getPhoneNumber()))
+			.companyId(companyId)
+			.build();
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/HubManagerSignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/HubManagerSignUpRequest.java
@@ -1,0 +1,30 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HubManagerSignUpRequest extends SignUpRequest {
+	private HubId hubId;
+
+	@Override
+	public HubManagerSignUpCommand toCommand() {
+		return HubManagerSignUpCommand.builder()
+			.userName(getUserName())
+			.password(getPassword())
+			.email(new Email(getEmail()))
+			.name(new Name(getName()))
+			.slackId(new SlackId(getSlackId()))
+			.phoneNumber(new PhoneNumber(getPhoneNumber()))
+			.hubId(hubId)
+			.build();
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/MasterSignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/MasterSignUpRequest.java
@@ -1,0 +1,27 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MasterSignUpRequest extends SignUpRequest {
+
+	@Override
+	public MasterSignUpCommand toCommand() {
+		return MasterSignUpCommand.builder()
+			.userName(getUserName())
+			.password(getPassword())
+			.email(new Email(getEmail()))
+			.name(new Name(getName()))
+			.slackId(new SlackId(getSlackId()))
+			.phoneNumber(new PhoneNumber(getPhoneNumber()))
+			.build();
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/ShipperSignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/ShipperSignUpRequest.java
@@ -1,0 +1,37 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
+import com.shoonglogitics.userservice.domain.entity.ShipperType;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShipperSignUpRequest extends SignUpRequest {
+	private HubId hubId;
+	private ShipperType shipperType;
+	private Integer order;
+	private Boolean isShippingAvailable;
+
+	@Override
+	public Object toCommand() {
+		return ShipperSignUpCommand.builder()
+			.userName(getUserName())
+			.password(getPassword())
+			.email(new Email(getEmail()))
+			.name(new Name(getName()))
+			.slackId(new SlackId(getSlackId()))
+			.phoneNumber(new PhoneNumber(getPhoneNumber()))
+			.hubId(hubId != null ? hubId : null)
+			.shipperType(shipperType)
+			.order(order)
+			.isShippingAvailable(isShippingAvailable)
+			.build();
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
@@ -1,0 +1,32 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpRequest {
+
+	private String userName;
+	private String password;
+	private String userType; // MASTER, HUB_MANAGER, COMPANY_MANAGER, SHIPPER
+
+	private String email;
+	private String name;
+	private String slackId;
+	private String phoneNumber;
+
+	private UUID hubId;       // HUB_MANAGER, COMPANY_SHIPPER
+	private UUID companyId;   // COMPANY_MANAGER
+
+	private String shipperType; // SHIPPER
+	private Integer order;      // SHIPPER
+	private Boolean isShippingAvailable; // SHIPPER
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
@@ -1,32 +1,42 @@
 package com.shoonglogitics.userservice.presentation.dto.request;
 
-import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class SignUpRequest {
+@JsonTypeInfo(
+	use = JsonTypeInfo.Id.NAME,
+	include = JsonTypeInfo.As.PROPERTY,
+	property = "userType"
+)
+@JsonSubTypes({
+	@JsonSubTypes.Type(value = MasterSignUpRequest.class, name = "MASTER"),
+	@JsonSubTypes.Type(value = HubManagerSignUpRequest.class, name = "HUB_MANAGER"),
+	@JsonSubTypes.Type(value = CompanyManagerSignUpCommand.class, name = "COMPANY_MANAGER"),
+	@JsonSubTypes.Type(value = ShipperSignUpCommand.class, name = "SHIPPER")
+})
+public abstract class SignUpRequest {
 
 	private String userName;
 	private String password;
-	private String userType; // MASTER, HUB_MANAGER, COMPANY_MANAGER, SHIPPER
+	//private String userType; // MASTER, HUB_MANAGER, COMPANY_MANAGER, SHIPPER
 
 	private String email;
 	private String name;
 	private String slackId;
 	private String phoneNumber;
 
-	private UUID hubId;       // HUB_MANAGER, COMPANY_SHIPPER
+	/*private UUID hubId;       // HUB_MANAGER, COMPANY_SHIPPER
 	private UUID companyId;   // COMPANY_MANAGER
 
 	private String shipperType; // SHIPPER
 	private Integer order;      // SHIPPER
-	private Boolean isShippingAvailable; // SHIPPER
+	private Boolean isShippingAvailable; // SHIPPER*/
+
+	public abstract <T> T toCommand();
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
@@ -23,19 +23,11 @@ public abstract class SignUpRequest {
 
 	private String userName;
 	private String password;
-	//private String userType; // MASTER, HUB_MANAGER, COMPANY_MANAGER, SHIPPER
 
 	private String email;
 	private String name;
 	private String slackId;
 	private String phoneNumber;
-
-	/*private UUID hubId;       // HUB_MANAGER, COMPANY_SHIPPER
-	private UUID companyId;   // COMPANY_MANAGER
-
-	private String shipperType; // SHIPPER
-	private Integer order;      // SHIPPER
-	private Boolean isShippingAvailable; // SHIPPER*/
 
 	public abstract <T> T toCommand();
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/UpdateSignupStatusRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/UpdateSignupStatusRequest.java
@@ -1,0 +1,10 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateSignupStatusRequest {
+
+	private String status;
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/response/SignUpResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/response/SignUpResponse.java
@@ -1,0 +1,18 @@
+package com.shoonglogitics.userservice.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpResponse {
+
+	private String userName;
+	private String userType;
+	private String status;
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/JwtAuthenticationFilter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.shoonglogitics.userservice.security;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shoonglogitics.userservice.application.command.LoginUserCommand;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+	private final JwtProvider jwtProvider;
+
+	public JwtAuthenticationFilter(AuthenticationManager authenticationManager,
+		JwtProvider jwtProvider) {
+		super(authenticationManager);
+		this.jwtProvider = jwtProvider;
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+		throws AuthenticationException {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			LoginUserCommand command = mapper.readValue(request.getInputStream(), LoginUserCommand.class);
+
+			System.out.println("member = " + command);
+
+			UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+				command.getUserName(), command.getPassword());
+
+			Authentication authentication = getAuthenticationManager().authenticate(authenticationToken);
+
+			return authentication;
+		} catch (IOException e) {
+			throw new AuthenticationServiceException("Failed to parse login request", e);
+		}
+	}
+
+	@Override
+	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+		Authentication authResult) throws IOException, ServletException {
+		UserDetailsImpl userDetails = (UserDetailsImpl)authResult.getPrincipal();
+
+		String token = jwtProvider.generateToken(
+			userDetails.getId(),
+			userDetails.getAuthorities().iterator().next().getAuthority()
+		);
+
+		// Response Header에 토큰 전달
+		response.addHeader("Authorization", "Bearer " + token);
+		response.addHeader("X-USER-ID", String.valueOf(userDetails.getUser().getId()));
+		response.addHeader("X-USER-ROLE", userDetails.getAuthorities().iterator().next().getAuthority());
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/JwtProvider.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/JwtProvider.java
@@ -1,0 +1,91 @@
+package com.shoonglogitics.userservice.security;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtProvider {
+
+	@Value("${jwt.secret}")
+	private String jwtSecret;
+
+	@Value("${jwt.expiration}")
+	private long jwtExpirationInMs;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	// JWT 토큰 생성
+	public String generateToken(Long userId, String role) {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("X-USER-ID", userId);
+		claims.put("X-USER-ROLE", role);
+
+		String token = Jwts.builder()
+			.setClaims(claims)
+			.setSubject(userId.toString())
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + jwtExpirationInMs))
+			.signWith(SignatureAlgorithm.HS256, jwtSecret)
+			.compact();
+
+		Map<String, String> tokenData = new HashMap<>();
+		tokenData.put("userId", String.valueOf(userId));
+		tokenData.put("userRole", role);
+
+		redisTemplate.opsForHash().putAll(token, tokenData);
+
+		return token;
+	}
+
+	// Jwt 토큰 검증
+	public boolean validateToken(String token) {
+		try {
+			// Jwt 토큰 서명용 Key
+			SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtSecret));
+			// Jwt 토큰 파싱을 통해 서명이 유효한지 확인
+			Claims claims = Jwts.parser()
+				.setSigningKey(key)
+				.build().parseClaimsJws(token).getBody();
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	// Jwt 토큰에서 Claims 추출 메소드
+	private Claims getAllClaimsFromToken(String token) {
+		SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtSecret));
+		Claims claims = Jwts.parser().setSigningKey(key)
+			.build().parseClaimsJws(token).getBody();
+
+		return claims;
+	}
+
+	// Jwt 토큰에서 UserID 추출
+	public String getUserIdFromToken(String token) {
+		Claims claims = getAllClaimsFromToken(token);
+		return claims.get("X-USER-ID", String.class);
+	}
+
+	// Jwt 토큰에서 User Role 추출
+	public String getUserRoleFromToken(String token) {
+		Claims claims = getAllClaimsFromToken(token);
+		return claims.get("X-USER-ROLE", String.class);
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 			.formLogin(form -> form.disable())
 			.httpBasic(basic -> basic.disable())
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/v1/users/login", "/api/v1/users/signup", "/api/v1/users/**").permitAll()
+				.requestMatchers("/api/v1/users/login", "/api/v1/users/signup", "/api/v1/users").permitAll()
 				.anyRequest().authenticated()
 			);
 		return http.build();

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 			.formLogin(form -> form.disable())
 			.httpBasic(basic -> basic.disable())
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/v1/users/login", "/api/v1/users/signup", "/api/v1/users").permitAll()
+				.requestMatchers("/api/v1/users/login", "/api/v1/users/signup", "/api/v1/users/**").permitAll()
 				.anyRequest().authenticated()
 			);
 		return http.build();

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.shoonglogitics.userservice.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final AuthenticationConfiguration authenticationConfiguration;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws
+		Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.disable())
+			.sessionManagement(sm -> sm.sessionCreationPolicy(
+				SessionCreationPolicy.STATELESS
+			))
+			.formLogin(form -> form.disable())
+			.httpBasic(basic -> basic.disable())
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/v1/users/login", "/api/v1/users/signup", "/api/v1/users/**").permitAll()
+				.anyRequest().authenticated()
+			);
+		return http.build();
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/UserDetailsImpl.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/UserDetailsImpl.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import com.shoonglogitics.userservice.domain.entity.SignupStatus;
 import com.shoonglogitics.userservice.domain.entity.User;
 import com.shoonglogitics.userservice.domain.entity.UserRole;
 
@@ -50,7 +51,7 @@ public class UserDetailsImpl implements UserDetails {
 
 	@Override
 	public boolean isAccountNonExpired() {
-		return true;
+		return user.getSignupStatus() == SignupStatus.APPROVED;
 	}
 
 	@Override
@@ -65,7 +66,7 @@ public class UserDetailsImpl implements UserDetails {
 
 	@Override
 	public boolean isEnabled() {
-		return true;
+		return user.getSignupStatus() == SignupStatus.APPROVED;
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/UserDetailsImpl.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/UserDetailsImpl.java
@@ -1,0 +1,71 @@
+package com.shoonglogitics.userservice.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.shoonglogitics.userservice.domain.entity.User;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+	private final User user;
+
+	public User getUser() {
+		return user;
+	}
+
+	public Long getId() {
+		return user.getId();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		UserRole role = user.getUserRole();
+		String authority = role.getAuthority();
+
+		SimpleGrantedAuthority simpleGrantedAuthority =
+			new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getUserName();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/security/UserDetailsServiceImpl.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/security/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package com.shoonglogitics.userservice.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.domain.entity.User;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new UsernameNotFoundException(
+				username + "의 아이디로 회원을 찾을 수 없습니다.// TODO : AndDeletedAtIsNull도 추가하기"));
+
+		return new UserDetailsImpl(user);
+	}
+
+}

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=user-service

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: user-service
+
+# TODO : configure-service? ??
+jwt:
+  secret: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"
+  expiration: 3600000

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -2,6 +2,22 @@ spring:
   application:
     name: user-service
 
+  datasource:
+    url: jdbc:mysql://localhost:3306/userDB?useSSL=false&serverTimezone=Asia/Seoul
+    username: root
+    password: brian981103
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
 # TODO : configure-service? ??
 jwt:
   secret: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"

--- a/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
+++ b/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
@@ -1,0 +1,191 @@
+package com.shoonglogitics.userservice.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
+import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
+import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
+import com.shoonglogitics.userservice.domain.entity.CompanyManager;
+import com.shoonglogitics.userservice.domain.entity.HubManager;
+import com.shoonglogitics.userservice.domain.entity.Master;
+import com.shoonglogitics.userservice.domain.entity.Shipper;
+import com.shoonglogitics.userservice.domain.entity.ShipperType;
+import com.shoonglogitics.userservice.domain.entity.User;
+import com.shoonglogitics.userservice.domain.entity.UserRole;
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+import com.shoonglogitics.userservice.domain.vo.CompanyId;
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.HubId;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private EntityManager em;
+
+	@Autowired
+	private UserService userService;
+
+	@Test
+	@DisplayName("Master 저장 테스트")
+	void save_master() {
+		MasterSignUpCommand command = MasterSignUpCommand.builder()
+			.userName("master1")
+			.password("12345678")
+			.email(new Email("master@gmail.com"))
+			.name(new Name("이수현"))
+			.slackId(new SlackId("Slack1"))
+			.phoneNumber(new PhoneNumber("010-1111-2222"))
+			.build();
+
+		userService.signUp(command);
+
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("master1").orElseThrow();
+		assertThat(user.getUserRole()).isEqualTo(UserRole.MASTER);
+		assertThat(user).isInstanceOf(Master.class);
+
+		Master master = (Master)user;
+		assertThat(master.getEmail().getValue()).isEqualTo("master@gmail.com");
+	}
+
+	@Test
+	@DisplayName("HubManager 저장 테스트")
+	void save_hubManager() {
+		HubManagerSignUpCommand command = HubManagerSignUpCommand.builder()
+			.userName("hub1")
+			.password("12345678")
+			.email(new Email("hub@gmail.com"))
+			.name(new Name("홍길동"))
+			.hubId(new HubId(UUID.randomUUID()))
+			.slackId(new SlackId("HubSlack1"))
+			.phoneNumber(new PhoneNumber("010-2222-3333"))
+			.build();
+
+		userService.signUp(command);
+
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("hub1").orElseThrow();
+		assertThat(user).isInstanceOf(HubManager.class);
+
+		HubManager hubManager = (HubManager)user;
+		assertThat(hubManager.getHubId()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("CompanyManager 저장 테스트")
+	void save_companyManager() {
+		CompanyManagerSignUpCommand command = CompanyManagerSignUpCommand.builder()
+			.userName("company1")
+			.password("12345678")
+			.email(new Email("company@gmail.com"))
+			.name(new Name("김회사"))
+			.companyId(new CompanyId(UUID.randomUUID()))
+			.slackId(new SlackId("CompanySlack1"))
+			.phoneNumber(new PhoneNumber("010-3333-4444"))
+			.build();
+
+		userService.signUp(command);
+
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("company1").orElseThrow();
+		assertThat(user).isInstanceOf(CompanyManager.class);
+
+		CompanyManager companyManager = (CompanyManager)user;
+		assertThat(companyManager.getCompanyId()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("Shipper 저장 테스트")
+	void save_shipper() {
+		ShipperSignUpCommand command = ShipperSignUpCommand.builder()
+			.userName("shipper1")
+			.password("12345678")
+			.email(new Email("shipper@gmail.com"))
+			.name(new Name("배달원"))
+			.hubId(new HubId(UUID.randomUUID()))
+			.slackId(new SlackId("ShipperSlack1"))
+			.phoneNumber(new PhoneNumber("010-4444-5555"))
+			.order(1)
+			.isShippingAvailable(true)
+			.shipperType(ShipperType.COMPANY_SHIPPER)
+			.build();
+
+		userService.signUp(command);
+
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("shipper1").orElseThrow();
+		assertThat(user).isInstanceOf(Shipper.class);
+
+		Shipper shipper = (Shipper)user;
+		assertThat(shipper.getShipperType()).isEqualTo(ShipperType.COMPANY_SHIPPER);
+	}
+
+	@Test
+	@DisplayName("업체 배송담당자면 hubId 없으면 예외 발생")
+	void companyShipperWithoutHubId_shouldFail() {
+		ShipperSignUpCommand command = ShipperSignUpCommand.builder()
+			.userName("shipper2")
+			.password("12345678")
+			.email(new Email("shipper2@gmail.com"))
+			.name(new Name("홍길동"))
+			.slackId(new SlackId("slack1"))
+			.phoneNumber(new PhoneNumber("010-1111-2222"))
+			.shipperType(ShipperType.COMPANY_SHIPPER)
+			.hubId(null) // hubId 누락
+			.order(1)
+			.isShippingAvailable(true)
+			.build();
+
+		assertThatThrownBy(() -> userService.signUp(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("업체 배송 담당자는 허브 ID가 반드시 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("허브 배송담당자면 hubId 있으면 예외 발생")
+	void hubShipperWithHubId_shouldFail() {
+		ShipperSignUpCommand command = ShipperSignUpCommand.builder()
+			.userName("shipper3")
+			.password("12345678")
+			.email(new Email("shipper3@gmail.com"))
+			.name(new Name("김철수"))
+			.slackId(new SlackId("slack2"))
+			.phoneNumber(new PhoneNumber("010-2222-3333"))
+			.shipperType(ShipperType.HUB_SHIPPER)
+			.hubId(new HubId(UUID.randomUUID())) // hubId 존재 → 예외
+			.order(1)
+			.isShippingAvailable(true)
+			.build();
+
+		assertThatThrownBy(() -> userService.signUp(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("허브 배송 담당자는 허브 ID가 없어야 합니다.");
+	}
+}


### PR DESCRIPTION
### 연관이슈(이슈번호)

### 변경사항
- User root엔티티를 기준으로 나머지 관리자 엔티티들이 상속받는 형식이라 id값이 Long으로 통일이 되어야할 것 같습니다.
- 회원 조회에 검색조건은 제외 했습니다.

### 리뷰요청
- dev로 병합 할 수 있게 변경했습니다.
- 첫번째 commit은 그저 설계이므로 안보셔도 무방합니다.
- 기존 PR은 "[feat] : 회원 전체 조회 로직 전략 패턴 적용" 까지였으며 코멘트 달아주신 부분들 수정하여 그 이후에 commit부터 보시면 됩니다.
- JsonTypeInfo, JsonSubType 적용하여 리팩토링 했습니다.
- 회원가입, 회원 전체조회, 단건조회, 회원가입 승인/거절 기능구현했습니다.
- 원래는 전체조회까지만 있었는데 어제 추가로 개발을 하느라 다 push를 할 수 밖에 없었습니다.. 양이 너무 많은 점 죄송합니다.