### PR TITLE
[feat] Hub 도메인 Entity, vo, domainEvent 생성

### DIFF
--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -25,6 +25,11 @@ repositories {
 }
 
 dependencies {
+
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
+    implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -26,8 +26,9 @@ repositories {
 
 dependencies {
 
+    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.hibernate:hibernate-spatial:6.4.4.Final'
     implementation 'org.locationtech.jts:jts-core:1.19.0'
-    implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -35,6 +36,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    
+
 }
 
 tasks.named('test') {

--- a/hub-service/docker-compose-local.yml
+++ b/hub-service/docker-compose-local.yml
@@ -1,0 +1,23 @@
+services:
+  postgres:
+    image: postgis/postgis:16-3.4
+    container_name: postgis-db
+    restart: always
+    user: root  # 로케일 설치를 위해 root 필요
+    environment:
+      POSTGRES_USER:
+      POSTGRES_PASSWORD:
+    entrypoint: |
+      bash -c "
+      apt-get update && apt-get install -y locales &&
+      sed -i '/ko_KR.UTF-8/s/^# //g' /etc/locale.gen &&
+      locale-gen ko_KR.UTF-8 &&
+      su postgres -c 'postgres -D /var/lib/postgresql/data'
+      "
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-dev-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-dev-data:

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/Hub.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/Hub.java
@@ -1,0 +1,123 @@
+package com.shoonglogitics.hubservice.domain.entity;
+
+
+import com.shoonglogitics.hubservice.domain.entity.common.BaseAggregateRoot;
+import com.shoonglogitics.hubservice.domain.event.HubCreatedEvent;
+import com.shoonglogitics.hubservice.domain.event.HubDeactivatedEvent;
+import com.shoonglogitics.hubservice.domain.event.HubRenamedEvent;
+import com.shoonglogitics.hubservice.domain.vo.Address;
+import com.shoonglogitics.hubservice.domain.vo.HubType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+@Entity
+@Table(name = "p_hubs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hub extends BaseAggregateRoot<Hub> {
+
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(nullable = false, length = 100, unique = true)
+    private String name;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "address"))
+    private Address address;
+
+    @Column(nullable = false, columnDefinition = "geometry(Point, 4326)")
+    private Point location;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "hub_type", nullable = false, length = 20)
+    private HubType hubType;
+
+
+    @Builder
+    public Hub(String name, Address address, Point location, HubType hubType) {
+        this.name = name;
+        this.address = address;
+        this.location = location;
+        this.hubType = hubType;
+    }
+
+    public static Hub create(String name, String addressValue, Double latitude, Double longitude, HubType hubType) {
+        Hub hub = Hub.builder()
+                .name(name)
+                .address(Address.of(addressValue))
+                .location(createPoint(latitude, longitude))
+                .hubType(hubType)
+                .build();
+
+        hub.registerEvent(new HubCreatedEvent(
+                hub.getId(),
+                name,
+                addressValue,
+                latitude,
+                longitude
+        ));
+
+        return hub;
+
+    }
+
+    public void update(String name){
+        String oldName = this.name;
+        this.name = name;
+        registerEvent(new HubRenamedEvent(this.id, oldName, name));
+    }
+
+    public void deactivate(Long userId){
+        if(this.isDeleted()){
+            throw new IllegalStateException("이미 삭제된 허브입니다.");
+        }
+
+        this.softDelete(userId);
+        registerEvent(new HubDeactivatedEvent(this.id));
+    }
+
+
+    public boolean isCentralHub(){
+        return this.hubType == HubType.CENTRAL;
+    }
+
+    public Double getLatitude(){
+        return location != null ? location.getY() : null;
+    }
+
+    public Double getLongitude(){
+        return location != null ? location.getX() : null;
+    }
+
+    private static Point createPoint(Double latitude, Double longitude){
+        if(latitude == null || longitude == null){
+            return null;
+        }
+
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+        Coordinate coordinate = new Coordinate(longitude, latitude);
+        return geometryFactory.createPoint(coordinate);
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/HubRoute.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/HubRoute.java
@@ -1,11 +1,15 @@
 package com.shoonglogitics.hubservice.domain.entity;
 
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
 
 import com.shoonglogitics.hubservice.domain.entity.common.BaseEntity;
 import com.shoonglogitics.hubservice.domain.vo.Distance;
 import com.shoonglogitics.hubservice.domain.vo.Duration;
 import com.shoonglogitics.hubservice.domain.vo.HubId;
 import com.shoonglogitics.hubservice.domain.vo.RouteType;
+
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -14,11 +18,9 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_hub_routes")
@@ -26,58 +28,58 @@ import org.hibernate.annotations.UuidGenerator;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HubRoute extends BaseEntity {
 
-    @Id
-    @UuidGenerator(style = UuidGenerator.Style.TIME)
-    @Column(name = "id", columnDefinition = "uuid")
-    private UUID id;
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.TIME)
+	@Column(name = "id", columnDefinition = "uuid")
+	private UUID id;
 
-    @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "departure_hub_id", nullable = false))
-    private HubId departureHubId;
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "departure_hub_id", nullable = false))
+	private HubId departureHubId;
 
-    @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "arrival_hub_id", nullable = false))
-    private HubId arrivalHubId;
+	@Embedded
+	@AttributeOverride(name = "value", column = @Column(name = "arrival_hub_id", nullable = false))
+	private HubId arrivalHubId;
 
-    @Embedded
-    @AttributeOverride(name = "meters", column = @Column(name = "distance_meters"))
-    private Distance distanceMeters;
+	@Embedded
+	@AttributeOverride(name = "meters", column = @Column(name = "distance_meters"))
+	private Distance distanceMeters;
 
-    @Embedded
-    @AttributeOverride(name = "minutes", column = @Column(name = "duration_minutes"))
-    private Duration durationMinutes;
+	@Embedded
+	@AttributeOverride(name = "minutes", column = @Column(name = "duration_minutes"))
+	private Duration durationMinutes;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "route_type", nullable = false, length = 20)
-    private RouteType routeType;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "route_type", nullable = false, length = 20)
+	private RouteType routeType;
 
+	public static HubRoute create(HubId departure, HubId arrival,
+		Distance distance, Duration duration, RouteType type) {
+		validate(departure, arrival, distance, duration);
 
-    public static HubRoute create(HubId departure, HubId arrival,
-                                  Distance distance, Duration duration, RouteType type) {
-        validate(departure, arrival, distance, duration);
+		HubRoute route = new HubRoute();
+		route.departureHubId = departure;
+		route.arrivalHubId = arrival;
+		route.distanceMeters = distance;
+		route.durationMinutes = duration;
+		route.routeType = type;
+		//reviewer 질문 : event 발행?
+		return route;
+	}
 
-        HubRoute route = new HubRoute();
-        route.departureHubId = departure;
-        route.arrivalHubId = arrival;
-        route.distanceMeters = distance;
-        route.durationMinutes = duration;
-        route.routeType = type;
-        //reviewer 질문 : event 발행?
-        return route;
-    }
-    private static void validate(HubId departure, HubId arrival, Distance distance, Duration duration) {
-        if (departure == null || arrival == null) {
-            throw new IllegalArgumentException("출발/도착 허브는 필수입니다.");
-        }
-        if (departure.getId().equals(arrival.getId())) {
-            throw new IllegalArgumentException("출발 허브와 도착 허브는 같을 수 없습니다.");
-        }
-        if (distance == null || distance.getMeters() <= 0) {
-            throw new IllegalArgumentException("이동거리는 0보다 커야 합니다.");
-        }
-        if (duration == null || duration.getMinutes() <= 0) {
-            throw new IllegalArgumentException("소요시간은 0보다 커야 합니다.");
-        }
-    }
+	private static void validate(HubId departure, HubId arrival, Distance distance, Duration duration) {
+		if (departure == null || arrival == null) {
+			throw new IllegalArgumentException("출발/도착 허브는 필수입니다.");
+		}
+		if (departure.getValue().equals(arrival.getValue())) {
+			throw new IllegalArgumentException("출발 허브와 도착 허브는 같을 수 없습니다.");
+		}
+		if (distance == null || distance.getMeters() <= 0) {
+			throw new IllegalArgumentException("이동거리는 0보다 커야 합니다.");
+		}
+		if (duration == null || duration.getMinutes() <= 0) {
+			throw new IllegalArgumentException("소요시간은 0보다 커야 합니다.");
+		}
+	}
 
 }

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/HubRoute.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/HubRoute.java
@@ -1,0 +1,83 @@
+package com.shoonglogitics.hubservice.domain.entity;
+
+
+import com.shoonglogitics.hubservice.domain.entity.common.BaseEntity;
+import com.shoonglogitics.hubservice.domain.vo.Distance;
+import com.shoonglogitics.hubservice.domain.vo.Duration;
+import com.shoonglogitics.hubservice.domain.vo.HubId;
+import com.shoonglogitics.hubservice.domain.vo.RouteType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(name = "p_hub_routes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubRoute extends BaseEntity {
+
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "departure_hub_id", nullable = false))
+    private HubId departureHubId;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "arrival_hub_id", nullable = false))
+    private HubId arrivalHubId;
+
+    @Embedded
+    @AttributeOverride(name = "meters", column = @Column(name = "distance_meters"))
+    private Distance distanceMeters;
+
+    @Embedded
+    @AttributeOverride(name = "minutes", column = @Column(name = "duration_minutes"))
+    private Duration durationMinutes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "route_type", nullable = false, length = 20)
+    private RouteType routeType;
+
+
+    public static HubRoute create(HubId departure, HubId arrival,
+                                  Distance distance, Duration duration, RouteType type) {
+        validate(departure, arrival, distance, duration);
+
+        HubRoute route = new HubRoute();
+        route.departureHubId = departure;
+        route.arrivalHubId = arrival;
+        route.distanceMeters = distance;
+        route.durationMinutes = duration;
+        route.routeType = type;
+        //reviewer 질문 : event 발행?
+        return route;
+    }
+    private static void validate(HubId departure, HubId arrival, Distance distance, Duration duration) {
+        if (departure == null || arrival == null) {
+            throw new IllegalArgumentException("출발/도착 허브는 필수입니다.");
+        }
+        if (departure.getId().equals(arrival.getId())) {
+            throw new IllegalArgumentException("출발 허브와 도착 허브는 같을 수 없습니다.");
+        }
+        if (distance == null || distance.getMeters() <= 0) {
+            throw new IllegalArgumentException("이동거리는 0보다 커야 합니다.");
+        }
+        if (duration == null || duration.getMinutes() <= 0) {
+            throw new IllegalArgumentException("소요시간은 0보다 커야 합니다.");
+        }
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/common/BaseAggregateRoot.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/common/BaseAggregateRoot.java
@@ -1,0 +1,55 @@
+package com.shoonglogitics.hubservice.domain.entity.common;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AbstractAggregateRoot;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseAggregateRoot<A extends BaseAggregateRoot<A>>
+        extends AbstractAggregateRoot<A>
+        implements BaseAuditEntity{
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private Long deletedBy;
+
+    @Override
+    public void softDelete(Long userId) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+    }
+
+    @Override
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/common/BaseAuditEntity.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/common/BaseAuditEntity.java
@@ -1,0 +1,15 @@
+package com.shoonglogitics.hubservice.domain.entity.common;
+
+import java.time.LocalDateTime;
+
+public interface BaseAuditEntity {
+    LocalDateTime getCreatedAt();
+    Long getCreatedBy();
+    LocalDateTime getUpdatedAt();
+    Long getUpdatedBy();
+    LocalDateTime getDeletedAt();
+    Long getDeletedBy();
+
+    void softDelete(Long userId);
+    boolean isDeleted();
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/common/BaseEntity.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/entity/common/BaseEntity.java
@@ -1,0 +1,50 @@
+package com.shoonglogitics.hubservice.domain.entity.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity implements BaseAuditEntity{
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private Long deletedBy;
+
+    @Override
+    public void softDelete(Long userId) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+    }
+
+    @Override
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubCreatedEvent.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubCreatedEvent.java
@@ -1,0 +1,24 @@
+package com.shoonglogitics.hubservice.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HubCreatedEvent extends HubDomainEvent{
+
+    private final UUID hubId;
+    private final String name;
+    private final String address;
+    private final Double latitude;
+    private final Double longitude;
+
+    public HubCreatedEvent(UUID hubId, String name, String address, Double latitude, Double longitude) {
+        super(LocalDateTime.now());
+        this.hubId = hubId;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubDeactivatedEvent.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubDeactivatedEvent.java
@@ -1,0 +1,17 @@
+package com.shoonglogitics.hubservice.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HubDeactivatedEvent extends HubDomainEvent{
+
+    private final UUID hubId;
+
+    public HubDeactivatedEvent(UUID hubId) {
+        super(LocalDateTime.now());
+        this.hubId = hubId;
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubDomainEvent.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubDomainEvent.java
@@ -1,0 +1,10 @@
+package com.shoonglogitics.hubservice.domain.event;
+
+import java.time.LocalDateTime;
+
+public class HubDomainEvent {
+    private final LocalDateTime occurredAt;
+
+    protected HubDomainEvent(LocalDateTime occurredAt) {this.occurredAt = LocalDateTime.now();}
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubRenamedEvent.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/event/HubRenamedEvent.java
@@ -1,0 +1,21 @@
+package com.shoonglogitics.hubservice.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HubRenamedEvent extends HubDomainEvent{
+
+    private final UUID hubId;
+    private final String oldName;
+    private final String newName;
+
+    public HubRenamedEvent(UUID hubId, String oldName, String newName){
+        super(LocalDateTime.now());
+        this.hubId = hubId;
+        this.oldName = oldName;
+        this.newName = newName;
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Address.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Address.java
@@ -1,6 +1,5 @@
 package com.shoonglogitics.hubservice.domain.vo;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -15,25 +14,24 @@ public class Address {
 
     private static final int ADDRESS_MAX_LENGTH = 100;
 
-    @Column(name = "address", nullable = false, length = 500)
     private String value;
 
 
-    private Address(String value){
+    private Address(String value) {
         validateAddress(value);
         this.value = value;
     }
 
-    private void validateAddress(String value){
-        if(value == null || value.isEmpty()){
+    private void validateAddress(String value) {
+        if (value == null || value.isEmpty()) {
             throw new IllegalArgumentException("주소는 필수입니다");
         }
-        if (value.length() > ADDRESS_MAX_LENGTH){
+        if (value.length() > ADDRESS_MAX_LENGTH) {
             throw new IllegalArgumentException("주소는 500자를 초과할 수 없습니다");
         }
     }
 
-    public static Address of(String value){
+    public static Address of(String value) {
         return new Address(value);
     }
 }

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Address.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Address.java
@@ -1,0 +1,39 @@
+package com.shoonglogitics.hubservice.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+
+    private static final int ADDRESS_MAX_LENGTH = 100;
+
+    @Column(name = "address", nullable = false, length = 500)
+    private String value;
+
+
+    private Address(String value){
+        validateAddress(value);
+        this.value = value;
+    }
+
+    private void validateAddress(String value){
+        if(value == null || value.isEmpty()){
+            throw new IllegalArgumentException("주소는 필수입니다");
+        }
+        if (value.length() > ADDRESS_MAX_LENGTH){
+            throw new IllegalArgumentException("주소는 500자를 초과할 수 없습니다");
+        }
+    }
+
+    public static Address of(String value){
+        return new Address(value);
+    }
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Distance.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Distance.java
@@ -1,0 +1,45 @@
+package com.shoonglogitics.hubservice.domain.vo;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Distance {
+
+    private static final int MIN_DISTANCE_METERS = 0;
+    private static final int MAX_DISTANCE_METERS = 1_000_000;
+
+    @Column(name = "distance_meters", nullable = false)
+    private Integer meters;
+
+    private Distance(Integer meters) {
+        validateDistance(meters);
+        this.meters = meters;
+    }
+
+    private void validateDistance(Integer meters) {
+        if(meters == null || meters <=MIN_DISTANCE_METERS){
+            throw new IllegalArgumentException("거리는 0보다 커야 합니다");
+        }
+        if(meters > MAX_DISTANCE_METERS){
+            throw new IllegalArgumentException("거리는 "+MAX_DISTANCE_METERS+"미터를 초과할 수 없습니다");
+        }
+    }
+
+    public static Distance ofMeters(Integer meters) {
+        return new Distance(meters);
+    }
+
+    public boolean isLongerThan(int thresholdMeters) {
+        return this.meters > thresholdMeters;
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Distance.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Distance.java
@@ -1,7 +1,6 @@
 package com.shoonglogitics.hubservice.domain.vo;
 
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -17,7 +16,6 @@ public class Distance {
     private static final int MIN_DISTANCE_METERS = 0;
     private static final int MAX_DISTANCE_METERS = 1_000_000;
 
-    @Column(name = "distance_meters", nullable = false)
     private Integer meters;
 
     private Distance(Integer meters) {
@@ -26,11 +24,11 @@ public class Distance {
     }
 
     private void validateDistance(Integer meters) {
-        if(meters == null || meters <=MIN_DISTANCE_METERS){
+        if (meters == null || meters <= MIN_DISTANCE_METERS) {
             throw new IllegalArgumentException("거리는 0보다 커야 합니다");
         }
-        if(meters > MAX_DISTANCE_METERS){
-            throw new IllegalArgumentException("거리는 "+MAX_DISTANCE_METERS+"미터를 초과할 수 없습니다");
+        if (meters > MAX_DISTANCE_METERS) {
+            throw new IllegalArgumentException("거리는 " + MAX_DISTANCE_METERS + "미터를 초과할 수 없습니다");
         }
     }
 

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Duration.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/Duration.java
@@ -1,0 +1,89 @@
+package com.shoonglogitics.hubservice.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public class Duration implements Comparable<Duration>{
+    private static final long WORKING_HOURS_MINUTES = 540;
+    private static final long MIN_MINUTES = 0;
+
+    private final long minutes;
+
+    private Duration(long minutes) {
+        validate(minutes);
+        this.minutes = minutes;
+    }
+
+
+    private void validate(long minutes) {
+        if (minutes < MIN_MINUTES) {
+            throw new IllegalArgumentException("소요 시간은 "+ MIN_MINUTES +"이상이어야 합니다: "+minutes);
+        }
+    }
+
+    public static Duration ofMinutes(long minutes) {
+        return new Duration(minutes);
+    }
+
+    public static Duration ofHours(long hours) {
+        return new Duration(hours*60);
+    }
+
+    public static Duration ofHoursAndMinutes(long hours, long minutes) {
+        return new Duration(hours*60+minutes);
+    }
+
+    public long toHours(){
+        return minutes/60;
+    }
+
+    public Duration add(Duration other) {
+        if(other == null) {
+            throw new IllegalArgumentException("더할 시간은 null일 수 없습니다");
+        }
+        return new Duration(minutes + other.minutes);
+    }
+
+    public Duration subtract(Duration other) {
+        if(other == null) {
+            throw new IllegalArgumentException("뺄 시간은 null일 수 없습니다");
+        }
+        return new Duration(minutes - other.minutes);
+    }
+
+
+    public boolean isGreaterThan(Duration other) {
+        if (other == null) {
+            throw new IllegalArgumentException("비교 대상은 null일 수 없습니다");
+        }
+        return this.minutes > other.minutes;
+    }
+
+    public boolean isLessThan(Duration other) {
+        if (other == null) {
+            throw new IllegalArgumentException("비교 대상은 null일 수 없습니다");
+        }
+        return this.minutes < other.minutes;
+    }
+
+    public boolean isWithinWorkingHours() {
+        return this.minutes <= WORKING_HOURS_MINUTES;
+    }
+
+    @Override
+    public int compareTo(Duration other) {
+        if(other == null) {
+            throw new IllegalArgumentException("비교 대상은 null일 수 없습니다");
+        }
+        return Long.compare(this.minutes, other.minutes);
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/HubId.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/HubId.java
@@ -1,6 +1,5 @@
 package com.shoonglogitics.hubservice.domain.vo;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -14,17 +13,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HubId {
 
-    @Column(name = "hub_id")
-    private UUID id;
+    private UUID value;
 
-    private HubId(UUID id) {
-        if(id == null) {
-            throw new IllegalArgumentException("유효하지 않은 허브 id 입니다");
+    private HubId(UUID value) {
+        if (value == null) {
+            throw new IllegalArgumentException("유효하지 않은 허브 value 입니다");
         }
-        this.id = id;
+        this.value = value;
     }
 
-    public static HubId of(UUID id){
+    public static HubId of(UUID id) {
         return new HubId(id);
     }
 

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/HubId.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/HubId.java
@@ -1,0 +1,31 @@
+package com.shoonglogitics.hubservice.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubId {
+
+    @Column(name = "hub_id")
+    private UUID id;
+
+    private HubId(UUID id) {
+        if(id == null) {
+            throw new IllegalArgumentException("유효하지 않은 허브 id 입니다");
+        }
+        this.id = id;
+    }
+
+    public static HubId of(UUID id){
+        return new HubId(id);
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/HubType.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/HubType.java
@@ -1,0 +1,42 @@
+package com.shoonglogitics.hubservice.domain.vo;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HubType {
+
+    CENTRAL("중앙허브", true),
+    NORMAL("일반허브", false);
+
+    private final String description;
+    private final boolean central;
+
+    public boolean isCentral(){
+        return central;
+    }
+
+    public boolean isNormal(){
+        return !central;
+    }
+
+    public static HubType from(String type) {
+        if (type == null || type.isBlank()) {
+            throw new IllegalArgumentException("허브 타입은 필수입니다");
+        }
+
+        return Arrays.stream(values())
+                .filter(t -> t.name().equalsIgnoreCase(type.trim()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "유효하지 않은 허브 타입입니다: " + type
+                ));
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/RouteType.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/domain/vo/RouteType.java
@@ -1,0 +1,47 @@
+package com.shoonglogitics.hubservice.domain.vo;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteType {
+
+    DIRECT("직접배송", "중간 허브 없이 직접 배송"),
+    RELAY("중계배송", "중간 허브를 거쳐 릴레이 배송"),
+    CENTRAL_HUB("중앙허브 경유", "중앙허브를 통한 배송");
+
+    private final String description;
+    private final String detail;
+
+    public boolean isDirect(){
+        return this == DIRECT;
+    }
+
+    public boolean isRelay(){
+        return this == RELAY;
+    }
+
+    public boolean isCentralHub(){
+        return this == CENTRAL_HUB;
+    }
+
+    public static RouteType from(String type){
+        if(type == null || type.isEmpty()){
+            throw new IllegalArgumentException("경로 타입은 필수입니다");
+        }
+        return Arrays.stream(values())
+                .filter(t -> t.name().equalsIgnoreCase(type.trim()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "유효하지 않은 경로 타입니다: " + type
+                ));
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/presentation/GlobalExceptionHandler.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/presentation/GlobalExceptionHandler.java
@@ -1,0 +1,119 @@
+package com.shoonglogitics.hubservice.presentation;
+
+import com.shoonglogitics.hubservice.presentation.dto.ApiResponse;
+import jakarta.validation.ConstraintViolation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleBusinessException(Exception e) {
+        log.warn("비즈니스 규칙 위반: {}", e.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "BUSINESS_RULE_VIOLATION",
+                e.getMessage(),
+                HttpStatus.BAD_REQUEST.value()
+        );
+
+        return ResponseEntity.badRequest().body(ApiResponse.error(errorResponse));
+    }
+
+    @ExceptionHandler(java.util.NoSuchElementException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleNotFoundException(java.util.NoSuchElementException e) {
+        log.warn("리소스 없음: {}", e.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "RESOURCE_NOT_FOUND",
+                e.getMessage(),
+                HttpStatus.NOT_FOUND.value()
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(errorResponse));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleValidationException(MethodArgumentNotValidException e) {
+        log.warn("입력 검증 실패: {}", e.getMessage());
+
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("입력 검증 실패");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "VALIDATION_FAILED",
+                message,
+                HttpStatus.BAD_REQUEST.value()
+        );
+
+        return ResponseEntity.badRequest().body(ApiResponse.error(errorResponse));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleBindException(BindException e) {
+        log.warn("바인딩 예외: {}", e.getMessage());
+
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("바인딩 예외");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "BINDING_ERROR",
+                message,
+                HttpStatus.BAD_REQUEST.value()
+        );
+
+        return ResponseEntity.badRequest().body(ApiResponse.error(errorResponse));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleConstraintViolationException(ConstraintViolationException e) {
+        log.warn("제약 위반: {}", e.getMessage());
+
+        String message = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElse("제약 위반이 발생했습니다");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "CONSTRAINT_VIOLATION",
+                message,
+                HttpStatus.BAD_REQUEST.value()
+        );
+
+        return ResponseEntity.badRequest().body(ApiResponse.error(errorResponse));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleInternalServerError(Exception e) {
+        log.error("서버 내부 오류 발생", e);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "INTERNAL_SERVER_ERROR",
+                "서버 오류가 발생했습니다",
+                HttpStatus.INTERNAL_SERVER_ERROR.value()
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(errorResponse));
+    }
+
+    /**
+     * 에러 응답 DTO
+     */
+    public record ErrorResponse(
+            String code,
+            String message,
+            Integer status
+    ) {}
+}

--- a/hub-service/src/main/java/com/shoonglogitics/hubservice/presentation/dto/ApiResponse.java
+++ b/hub-service/src/main/java/com/shoonglogitics/hubservice/presentation/dto/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.shoonglogitics.hubservice.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+        boolean success,
+        String message,
+        T data,
+        Long timestamp
+) {
+    /**
+     * 성공 응답 생성 (데이터 포함)
+     */
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null, data, System.currentTimeMillis());
+    }
+
+    /**
+     * 성공 응답 생성 (데이터 + 메시지)
+     */
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>(true, message, data, System.currentTimeMillis());
+    }
+
+    /**
+     * 성공 응답 생성 (메시지만)
+     */
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null, System.currentTimeMillis());
+    }
+
+    /**
+     * 실패 응답 생성 (에러 데이터)
+     */
+    public static <T> ApiResponse<T> error(T errorData) {
+        return new ApiResponse<>(false, null, errorData, System.currentTimeMillis());
+    }
+}

--- a/hub-service/src/main/resources/application.properties
+++ b/hub-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=hub-service

--- a/hub-service/src/main/resources/application.yml
+++ b/hub-service/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: hub-service
+
+
+  profiles:
+    active: local  # 기본 프로파일
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+
+server:
+  port: 19092


### PR DESCRIPTION
### 연관이슈
closes #4 

### 변경사항
- Hub entity 생성
- HubRoute entity 생성
- domain Event 작성 기준
  - 도메인 이벤트의 경우 추후 로직에서 이벤트가 일어나고 상태전이가 필요한 경우를 기준으로 작성했습니다.
  - ex) HubRenamedEvent -> 캐싱된 루트정보 무효화
- vo 생성 기준
  - 값으로 존재할 수 있는 경우는 vo 객체로 선언하여 각 값을 검증할 수 있도록 생성하였습니다.

### 리뷰요청(질문)
- domain event 는 애그리거트 루트(abstractAggregateRoot<T>)에서 호출하고 생성할 수 있는데, Hub Route 의 경우 새로운 hub route 가 생성될때 루트 계산 변경이 일어나야 합니다.
- hub route 의 경우는 애그리거트 루트가 아닌상황인데, HubCreateEvent 에서 새로운 HubRoute 생성 및 루트 변경(새로 계산)이 이루어지는게 맞을까요?