### PR TITLE
[feat] 업체 삭제 API 구현

### DIFF
--- a/company-service/settings.gradle
+++ b/company-service/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'company-service'

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/CompanyService.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/CompanyService.java
@@ -14,6 +14,7 @@ import com.shoonglogitics.companyservice.domain.common.vo.GeoLocation;
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
 import com.shoonglogitics.companyservice.domain.company.repository.CompanyRepository;
 import com.shoonglogitics.companyservice.domain.company.vo.CompanyAddress;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,6 +28,7 @@ public class CompanyService {
 	@Transactional
 	public UUID createCompany(CreateCompanyCommand command) {
 		validateHubManager(command.authUser(), command.hubId());
+		validateDuplicateCompany(command.name(), command.zipCode(), command.type());
 
 		CompanyAddress address = CompanyAddress.of(command.address(), command.addressDetail(), command.zipCode());
 		GeoLocation location = GeoLocation.of(command.latitude(), command.longitude());
@@ -49,5 +51,11 @@ public class CompanyService {
 		if (authUser.getRole().isHubManager() && !userClient.isHubManager(authUser, hubId)) {
 			throw new IllegalArgumentException("해당 허브의 담당자만 업체를 생성, 삭제 할 수 있습니다.");
 		}
+	}
+
+	private void validateDuplicateCompany(String name, String zipCode, CompanyType type) {
+		companyRepository.findByNameAndZipCodeAndType(name, zipCode, type).ifPresent(company -> {
+			throw new IllegalArgumentException("이미 존재하는 업체입니다.");
+		});
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/command/CreateCompanyCommand.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/command/CreateCompanyCommand.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 public record CreateCompanyCommand(
 	AuthUser authUser,
 	UUID hubId,
-	Long currentUserId,
 	String name,
 	String address,
 	String addressDetail,

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/command/DeleteCompanyCommand.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/command/DeleteCompanyCommand.java
@@ -1,0 +1,12 @@
+package com.shoonglogitics.companyservice.application.command;
+
+import java.util.UUID;
+
+import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
+
+public record DeleteCompanyCommand(
+	AuthUser authUser,
+	UUID companyId,
+	UUID hubId
+) {
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/event/CompanyEventHandler.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/event/CompanyEventHandler.java
@@ -1,6 +1,12 @@
 package com.shoonglogitics.companyservice.application.event;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.shoonglogitics.companyservice.application.service.UserClient;
+import com.shoonglogitics.companyservice.domain.company.event.CompanyDeletedEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,4 +15,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class CompanyEventHandler {
+	private final UserClient userClient;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleCompanyDeleted(CompanyDeletedEvent event) {
+		userClient.deleteCompanyManager(event.getAuthUser(), event.getCompanyId());
+	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/service/UserClient.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/service/UserClient.java
@@ -1,15 +1,24 @@
 package com.shoonglogitics.companyservice.application.service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
+
+import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
 
 public interface UserClient {
 
 	/**
-	 * @param userId
+	 * @param authUser
 	 * @param hubId
 	 * @return 허브 담당자 아이디와 허브 아이디가 일치하는지 여부
 	 */
-	boolean isHubManager(Long userId, UUID hubId);
+	boolean isHubManager(AuthUser authUser, UUID hubId);
+
+	/**
+	 * @param companyId 업체 ID
+	 * @return 업체 담당자 삭제 요청 성공 여부
+	 */
+	boolean deleteCompanyManager(AuthUser authUser, UUID companyId);
 
 	/**
 	 * User Service 응답 정보
@@ -27,7 +36,9 @@ public interface UserClient {
 		UUID companyId,    // COMPANY_MANAGER, SHIPPER
 		UUID shipperId,    // SHIPPER only
 		String shipperType, // SHIPPER only
-		Integer order      // SHIPPER only
+		Integer order,// SHIPPER only
+		LocalDateTime deleteAt,
+		Long deleteBy
 	) {
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Company.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Company.java
@@ -8,7 +8,9 @@ import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.annotations.Where;
 
 import com.shoonglogitics.companyservice.domain.common.entity.BaseAggregateRoot;
+import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
 import com.shoonglogitics.companyservice.domain.common.vo.GeoLocation;
+import com.shoonglogitics.companyservice.domain.company.event.CompanyDeletedEvent;
 import com.shoonglogitics.companyservice.domain.company.vo.CompanyAddress;
 import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 import com.shoonglogitics.companyservice.infrastructure.persistence.converter.GeoLocationConverter;
@@ -84,5 +86,11 @@ public class Company extends BaseAggregateRoot<Company> {
 		company.type = type;
 
 		return company;
+	}
+
+	public void delete(AuthUser authUser) {
+		this.softDelete(authUser.getUserId());
+		this.products.forEach(product -> product.softDelete(authUser.getUserId()));
+		this.registerEvent(new CompanyDeletedEvent(this.id, authUser));
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/event/CompanyDeletedEvent.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/event/CompanyDeletedEvent.java
@@ -1,0 +1,19 @@
+package com.shoonglogitics.companyservice.domain.company.event;
+
+import java.util.UUID;
+
+import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
+
+import lombok.Getter;
+
+@Getter
+public class CompanyDeletedEvent extends CompanyDomainEvent {
+	private UUID companyId;
+	private AuthUser authUser;
+
+	public CompanyDeletedEvent(UUID companyId, AuthUser authUser) {
+		super();
+		this.companyId = companyId;
+		this.authUser = authUser;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/event/CompanyDomainEvent.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/event/CompanyDomainEvent.java
@@ -1,0 +1,14 @@
+package com.shoonglogitics.companyservice.domain.company.event;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public abstract class CompanyDomainEvent {
+	private final LocalDateTime occurredAt;
+
+	protected CompanyDomainEvent() {
+		this.occurredAt = LocalDateTime.now();
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/CompanyRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/CompanyRepository.java
@@ -4,9 +4,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 public interface CompanyRepository {
 	Company save(Company company);
 
 	Optional<Company> findById(UUID id);
+
+	Optional<Company> findByNameAndZipCodeAndType(String name, String zipCode, CompanyType type);
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/SecurityConfig.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.shoonglogitics.companyservice.infrastructure.filter.GatewayAuthenticationFilter;
+import com.shoonglogitics.companyservice.infrastructure.security.GatewayAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/external/UserClientImpl.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/external/UserClientImpl.java
@@ -1,11 +1,15 @@
 package com.shoonglogitics.companyservice.infrastructure.external;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
 import com.shoonglogitics.companyservice.application.service.UserClient;
+import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
 import com.shoonglogitics.companyservice.presentation.company.common.dto.ApiResponse;
+import com.shoonglogitics.companyservice.presentation.company.common.dto.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,14 +21,37 @@ public class UserClientImpl implements UserClient {
 	private final UserFeignClient userFeignClient;
 
 	@Override
-	public boolean isHubManager(Long userId, UUID hubId) {
-		ApiResponse<UserInfo> response = userFeignClient.getUserInfo(userId);
+	public boolean isHubManager(AuthUser authUser, UUID hubId) {
+		ApiResponse<UserInfo> response = userFeignClient.getUserInfo(authUser.getUserId(), authUser.getUserId(),
+			authUser.getAuthority());
 
 		if (!response.success()) {
-			log.warn("사용자 정보 조회 실패 - userId: {}, message: {}", userId, response.message());
+			log.warn("사용자 정보 조회 실패 - userId: {}, message: {}", authUser.getUserId(), response.message());
 			throw new IllegalArgumentException(response.message());
 		}
 		UserInfo data = response.data();
 		return data.hubId().equals(hubId);
+	}
+
+	/**
+	 * @param companyId 업체 ID
+	 * @return 업체 담당자 삭제 요청 성공 여부
+	 */
+	@Override
+	public boolean deleteCompanyManager(AuthUser authUser, UUID companyId) {
+		ApiResponse<PageResponse<UserInfo>> response = userFeignClient.getUserInfos(companyId, false,
+			authUser.getUserId(), authUser.getAuthority());
+
+		if (!response.success() || response.data().getContent().isEmpty() || response.data().getContent() == null) {
+			log.warn("사용자 정보 조회 실패 - companyId: {}, message: {}", companyId, response.message());
+			throw new IllegalArgumentException(response.message());
+		}
+
+		List<UserInfo> users = response.data().getContent();
+		Optional<UserInfo> companyManager = users.stream().findFirst();
+
+		return companyManager
+			.map(m -> userFeignClient.deleteUser(m.userId()).success())
+			.orElse(false);
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/external/UserFeignClient.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/external/UserFeignClient.java
@@ -1,11 +1,18 @@
 package com.shoonglogitics.companyservice.infrastructure.external;
 
+import java.util.UUID;
+
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.shoonglogitics.companyservice.application.service.UserClient;
+import com.shoonglogitics.companyservice.infrastructure.security.HeaderType;
 import com.shoonglogitics.companyservice.presentation.company.common.dto.ApiResponse;
+import com.shoonglogitics.companyservice.presentation.company.common.dto.PageResponse;
 
 @FeignClient(name = "user-service", url = "${user-service.url}")
 public interface UserFeignClient {
@@ -13,5 +20,16 @@ public interface UserFeignClient {
 	 * User Service에서 사용자 정보 조회
 	 */
 	@GetMapping("/api/v1/users/{userId}")
-	ApiResponse<UserClient.UserInfo> getUserInfo(@PathVariable("userId") Long userId);
+	ApiResponse<UserClient.UserInfo> getUserInfo(@PathVariable("userId") Long userId,
+		@RequestHeader(HeaderType.USER_ID) Long currentUserId,
+		@RequestHeader(HeaderType.USER_ROLE) String currentUserRole);
+
+	@GetMapping("/api/v1/users")
+	ApiResponse<PageResponse<UserClient.UserInfo>> getUserInfos(@RequestParam("companyId") UUID companyId,
+		@RequestParam("isDeleted") Boolean isDeleted,
+		@RequestHeader(HeaderType.USER_ID) Long currentUserId,
+		@RequestHeader(HeaderType.USER_ROLE) String currentUserRole);
+
+	@DeleteMapping("/api/v1/users/{userId}")
+	ApiResponse<String> deleteUser(@PathVariable("userId") Long userId);
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/CompanyRepositoryAdapter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/CompanyRepositoryAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
 import com.shoonglogitics.companyservice.domain.company.repository.CompanyRepository;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,5 +24,10 @@ public class CompanyRepositoryAdapter implements CompanyRepository {
 	@Override
 	public Optional<Company> findById(UUID id) {
 		return jpaCompanyRepository.findById(id);
+	}
+
+	@Override
+	public Optional<Company> findByNameAndZipCodeAndType(String name, String zipCode, CompanyType type) {
+		return jpaCompanyRepository.findByNameAndAddress_ZipCodeAndType(name, zipCode, type);
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaCompanyRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaCompanyRepository.java
@@ -1,12 +1,15 @@
 package com.shoonglogitics.companyservice.infrastructure.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 @Repository
 public interface JpaCompanyRepository extends JpaRepository<Company, UUID> {
+	Optional<Company> findByNameAndAddress_ZipCodeAndType(String name, String zipCode, CompanyType type);
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/security/GatewayAuthenticationFilter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/security/GatewayAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.shoonglogitics.companyservice.infrastructure.filter;
+package com.shoonglogitics.companyservice.infrastructure.security;
 
 import java.io.IOException;
 import java.util.List;
@@ -20,15 +20,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class GatewayAuthenticationFilter extends OncePerRequestFilter {
-	private static final String USER_ID_HEADER = "X-User-Id";
-	private static final String USER_ROLE_HEADER = "X-User-Role";
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		String userIdHeader = request.getHeader(USER_ID_HEADER);
-		String roleHeader = request.getHeader(USER_ROLE_HEADER);
+		String userIdHeader = request.getHeader(HeaderType.USER_ID);
+		String roleHeader = request.getHeader(HeaderType.USER_ROLE);
 
 		if (userIdHeader != null && roleHeader != null) {
 			try {

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/security/HeaderType.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/security/HeaderType.java
@@ -1,0 +1,9 @@
+package com.shoonglogitics.companyservice.infrastructure.security;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class HeaderType {
+	public static final String USER_ID = "X-User-Id";
+	public static final String USER_ROLE = "X-User-Role";
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
@@ -33,13 +33,12 @@ public class CompanyController {
 
 	@PostMapping
 	@PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER')")
-	public ResponseEntity<ApiResponse<CreateCompanyResponse>> createOrder(
+	public ResponseEntity<ApiResponse<CreateCompanyResponse>> createCompany(
 		@Valid @RequestBody CreateCompanyRequest request,
 		@AuthenticationPrincipal AuthUser authUser) {
 		CreateCompanyCommand command = CreateCompanyCommand.builder()
 			.authUser(authUser)
 			.hubId(request.hubId())
-			.currentUserId(authUser.getUserId())
 			.name(request.name())
 			.address(request.address())
 			.addressDetail(request.addressDetail())

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
@@ -7,13 +7,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.shoonglogitics.companyservice.application.CompanyService;
 import com.shoonglogitics.companyservice.application.command.CreateCompanyCommand;
+import com.shoonglogitics.companyservice.application.command.DeleteCompanyCommand;
 import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
 import com.shoonglogitics.companyservice.presentation.company.common.dto.ApiResponse;
 import com.shoonglogitics.companyservice.presentation.company.dto.CreateCompanyRequest;
@@ -55,5 +59,20 @@ public class CompanyController {
 		);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	@DeleteMapping("/{companyId}")
+	@PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER')")
+	public ResponseEntity<ApiResponse<String>> deleteCompany(
+		@PathVariable UUID companyId,
+		@RequestParam UUID hubId,
+		@AuthenticationPrincipal AuthUser authUser) {
+		DeleteCompanyCommand command = new DeleteCompanyCommand(authUser, companyId, hubId);
+
+		companyService.deleteCompany(command);
+
+		String responseMessage = "업체가 정상적으로 삭제 되었습니다.";
+
+		return ResponseEntity.ok().body(ApiResponse.success(responseMessage));
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/PageResponse.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/PageResponse.java
@@ -1,0 +1,31 @@
+package com.shoonglogitics.companyservice.presentation.company.common.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+	private List<T> content;
+	private int page;
+	private int size;
+	private long totalElements;
+	private int totalPages;
+
+	public static <T> PageResponse<T> of(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages()
+		);
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/dto/CreateCompanyResponse.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/dto/CreateCompanyResponse.java
@@ -3,6 +3,6 @@ package com.shoonglogitics.companyservice.presentation.company.dto;
 import java.util.UUID;
 
 public record CreateCompanyResponse(
-	UUID orderId,
+	UUID companyId,
 	String message
 ) {}

--- a/user-service/settings.gradle
+++ b/user-service/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'user-service'


### PR DESCRIPTION
### 연관이슈(#21)

### 변경사항
- Security 패키지 위치 변경
- User Header 이름 상수화
- 업체 생성시 외부 API에 인증 헤더를 담도록 구현
- 공통 페이징 응답 추가
- 업체 삭제 구현

### 리뷰요청
- 일단 삭제할때 feign 클라이언트 실패 케이스를 정의를 안해뒀는데, 어떤식으로 정의할까요?