### PR TITLE
[feat] 회원 수정/삭제/FeignClient 전용 API 구현

### DIFF
--- a/api-gateway/src/main/java/com/example/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/example/apigateway/filter/JwtAuthenticationFilter.java
@@ -27,7 +27,8 @@ public class JwtAuthenticationFilter implements WebFilter {
 	private final TokenProvider tokenProvider;
 	private final List<String> whiteList = List.of(
 		"/api/v1/users/login",
-		"/api/v1/users/signup"
+		"/api/v1/users/signup",
+		"/api/v1/users/internal"
 	);
 
 	private static ServerHttpRequest createCustomRequest(ServerWebExchange exchange, String userId,
@@ -39,7 +40,7 @@ public class JwtAuthenticationFilter implements WebFilter {
 	}
 
 	private boolean isWhiteListPath(String requestPath) {
-		return whiteList.contains(requestPath);
+		return whiteList.contains(requestPath) || requestPath.contains("internal");
 	}
 
 	private String extractToken(String accessToken) {

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/SecurityConfig.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+	//
 	private final GatewayAuthenticationFilter gatewayAuthenticationFilter;
 
 	@Bean

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
@@ -45,8 +46,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
@@ -3,9 +3,12 @@ package com.shoonglogitics.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ComponentScan("com.shoonglogitics")
+@EnableJpaAuditing
+//@Profile(value = "test")
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
@@ -3,12 +3,13 @@ package com.shoonglogitics.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ComponentScan("com.shoonglogitics")
 @EnableJpaAuditing
-//@Profile(value = "test")
+@Profile(value = "test")
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/UserServiceApplication.java
@@ -3,13 +3,11 @@ package com.shoonglogitics.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ComponentScan("com.shoonglogitics")
 @EnableJpaAuditing
-@Profile(value = "test")
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/LoginUserCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/LoginUserCommand.java
@@ -1,7 +1,5 @@
 package com.shoonglogitics.userservice.application.command;
 
-import com.shoonglogitics.userservice.presentation.dto.request.LoginRequest;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,12 +11,5 @@ public class LoginUserCommand {
 
 	private String userName;
 	private String password;
-
-	public static LoginUserCommand from(LoginRequest dto) {
-		LoginUserCommand command = new LoginUserCommand();
-		command.userName = dto.userName();
-		command.password = dto.password();
-		return command;
-	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/LoginUserCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/LoginUserCommand.java
@@ -1,6 +1,6 @@
 package com.shoonglogitics.userservice.application.command;
 
-import com.shoonglogitics.userservice.presentation.dto.request.LoginRequestDto;
+import com.shoonglogitics.userservice.presentation.dto.request.LoginRequest;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +14,7 @@ public class LoginUserCommand {
 	private String userName;
 	private String password;
 
-	public static LoginUserCommand from(LoginRequestDto dto) {
+	public static LoginUserCommand from(LoginRequest dto) {
 		LoginUserCommand command = new LoginUserCommand();
 		command.userName = dto.userName();
 		command.password = dto.password();

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/ShipperSignUpCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/ShipperSignUpCommand.java
@@ -17,18 +17,16 @@ public class ShipperSignUpCommand extends SignUpUserCommand {
 
 	private ShipperType shipperType;
 	private HubId hubId;
-	private Integer order;
 	private Boolean isShippingAvailable;
 
 	@Builder
 	public ShipperSignUpCommand(String userName, String password, Name name,
 		Email email, SlackId slackId, PhoneNumber phoneNumber,
 		ShipperType shipperType, HubId hubId,
-		Integer order, Boolean isShippingAvailable) { // 필드 추가
+		Boolean isShippingAvailable) { // 필드 추가
 		super(userName, password, SignupStatus.PENDING, name, email, slackId, phoneNumber);
 		this.shipperType = shipperType;
 		this.hubId = hubId;
-		this.order = order;
 		this.isShippingAvailable = isShippingAvailable;
 	}
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/command/UpdateUserCommand.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/command/UpdateUserCommand.java
@@ -1,0 +1,20 @@
+package com.shoonglogitics.userservice.application.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserCommand {
+
+	private String name;
+
+	private String email;
+
+	private String slackId;
+
+	private String phoneNumber;
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/service/InternalUserService.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/service/InternalUserService.java
@@ -1,0 +1,50 @@
+package com.shoonglogitics.userservice.application.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.shoonglogitics.userservice.domain.repository.UserRepository;
+import com.shoonglogitics.userservice.infrastructure.client.response.CompanyManagerResponse;
+import com.shoonglogitics.userservice.infrastructure.client.response.HubManagerResponse;
+import com.shoonglogitics.userservice.infrastructure.client.response.ShipperResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InternalUserService {
+
+	private final UserRepository userRepository;
+
+	public List<?> getInternalUsers(UUID hubId, UUID companyId) {
+		List<Object> responses = new ArrayList<>();
+
+		if (hubId != null) {
+			List<HubManagerResponse> hubManagers = userRepository.findHubManagersByHubId(hubId)
+				.stream().map(HubManagerResponse::from)
+				.toList();
+
+			List<ShipperResponse> shippers = userRepository.findShippersByHubId(hubId)
+				.stream().map(ShipperResponse::from)
+				.toList();
+
+			responses.addAll(hubManagers);
+			responses.addAll(shippers);
+		}
+
+		if (companyId != null) {
+			List<CompanyManagerResponse> companyManagers =
+				userRepository.findCompanyManagersByCompanyId(companyId)
+					.stream().map(CompanyManagerResponse::from)
+					.toList();
+
+			responses.addAll(companyManagers);
+		}
+
+		return responses;
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/service/UserService.java
@@ -174,6 +174,20 @@ public class UserService {
 		return false;
 	}
 
+	// canUpdateUser랑 코드가 똑같지만
+	// 추후 update, delete가 권한별로 달라질 수 있다는 확장성을 고려하여 일부러 분리
+	public boolean canDeleteUser(String requesterRole, Long requesterId, Long targetUserId) {
+		if ("MASTER".equals(requesterRole)) {
+			return true;
+		}
+
+		if ("HUB_MANAGER".equals(requesterRole)) {
+			return canHubManager(requesterId, targetUserId);
+		}
+
+		return false;
+	}
+
 	@Transactional
 	public void updateUser(Long userId, UpdateUserCommand command) {
 		User user = userRepository.findById(userId)
@@ -189,6 +203,18 @@ public class UserService {
 		} else {
 			throw new IllegalArgumentException("업데이트가 불가능한 사용자 타입입니다.");
 		}
+	}
+
+	@Transactional
+	public void deleteUser(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 User를 찾을 수 없습니다."));
+
+		if (user.isDeleted()) {
+			throw new IllegalArgumentException("이미 삭제된 사용자입니다.");
+		}
+
+		user.softDelete(userId);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/ShipperSignUpStrategy.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/application/strategy/signup/ShipperSignUpStrategy.java
@@ -23,6 +23,14 @@ public class ShipperSignUpStrategy implements SignUpStrategy {
 			throw new IllegalArgumentException("이미 존재하는 SHIPPER 회원입니다.");
 		}
 
+		ShipperSignUpCommand shipperSignUpCommand = (ShipperSignUpCommand)signUpUserCommand;
+
+		Integer lastOrder = userRepository.findLastShipperOrderByHubId(shipperSignUpCommand.getHubId())
+			.orElse(0);
+		System.out.println("lastOrder = " + lastOrder);
+
+		Integer newOrder = lastOrder + 1;
+
 		// Shipper 객체를 직접 생성
 		Shipper shipper = Shipper.create(
 			command.getUserName(),
@@ -33,7 +41,7 @@ public class ShipperSignUpStrategy implements SignUpStrategy {
 			command.getSlackId(),
 			command.getPhoneNumber(),
 			command.getShipperType(),
-			command.getOrder(),
+			newOrder,
 			command.getIsShippingAvailable()
 		);
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/common/entity/BaseAuditEntity.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/common/entity/BaseAuditEntity.java
@@ -1,0 +1,21 @@
+package com.shoonglogitics.userservice.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+public interface BaseAuditEntity {
+	LocalDateTime getCreatedAt();
+
+	Long getCreatedBy();
+
+	LocalDateTime getUpdatedAt();
+
+	Long getUpdatedBy();
+
+	LocalDateTime getDeletedAt();
+
+	Long getDeletedBy();
+
+	void softDelete(Long userId);
+
+	boolean isDeleted();
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/common/entity/BaseEntity.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/common/entity/BaseEntity.java
@@ -1,0 +1,58 @@
+package com.shoonglogitics.userservice.domain.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity implements BaseAuditEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	@Column(name = "created_by", updatable = false)
+	private Long createdBy;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@LastModifiedBy
+	@Column(name = "updated_by")
+	private Long updatedBy;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+
+	@Override
+	public void softDelete(Long userId) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = userId;
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return this.deletedAt != null;
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/CompanyManager.java
@@ -21,7 +21,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Table(name = "p_company_manager")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CompanyManager extends User {
+public class CompanyManager extends User implements UserUpdatable {
 
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "company_id"))
@@ -68,6 +68,14 @@ public class CompanyManager extends User {
 			throw new IllegalArgumentException("Slack ID는 필수 값입니다.");
 		if (phoneNumber == null)
 			throw new IllegalArgumentException("전화번호는 필수 값입니다.");
+	}
+
+	@Override
+	public void updateUserInfo(Name name, Email email, SlackId slackId, PhoneNumber phoneNumber) {
+		this.name = name;
+		this.email = email;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/HubManager.java
@@ -21,7 +21,7 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "p_hub_manager")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class HubManager extends User {
+public class HubManager extends User implements UserUpdatable {
 
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "hub_id"))
@@ -81,5 +81,13 @@ public class HubManager extends User {
 			throw new IllegalArgumentException("Slack ID는 필수 값입니다.");
 		if (phoneNumber == null)
 			throw new IllegalArgumentException("전화번호는 필수 값입니다.");
+	}
+
+	@Override
+	public void updateUserInfo(Name name, Email email, SlackId slackId, PhoneNumber phoneNumber) {
+		this.name = name;
+		this.email = email;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
 	}
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Master.java
@@ -20,7 +20,7 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "p_master")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Master extends User {
+public class Master extends User implements UserUpdatable {
 
 	@Embedded
 	@AttributeOverride(name = "value", column = @Column(name = "email"))
@@ -67,6 +67,14 @@ public class Master extends User {
 		if (phoneNumber == null) {
 			throw new IllegalArgumentException("전화번호는 필수 값입니다.");
 		}
+	}
+
+	@Override
+	public void updateUserInfo(Name name, Email email, SlackId slackId, PhoneNumber phoneNumber) {
+		this.name = name;
+		this.email = email;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/Shipper.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "p_shipper")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Shipper extends User {
+public class Shipper extends User implements UserUpdatable {
 
 	@Embedded
 	@AttributeOverride(name = "id", column = @Column(name = "hub_id", nullable = true))
@@ -83,6 +83,14 @@ public class Shipper extends User {
 			.order(order)
 			.isShippingAvailable(isShippingAvailable)
 			.build();
+	}
+
+	@Override
+	public void updateUserInfo(Name name, Email email, SlackId slackId, PhoneNumber phoneNumber) {
+		this.name = name;
+		this.email = email;
+		this.slackId = slackId;
+		this.phoneNumber = phoneNumber;
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/User.java
@@ -1,5 +1,7 @@
 package com.shoonglogitics.userservice.domain.entity;
 
+import com.shoonglogitics.userservice.domain.common.entity.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
-public class User {
+public class User extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/UserUpdatable.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/entity/UserUpdatable.java
@@ -1,0 +1,10 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+public interface UserUpdatable {
+	void updateUserInfo(Name name, Email email, SlackId slackId, PhoneNumber phoneNumber);
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,7 +11,11 @@ import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponse
 import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
 import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
 import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
+import com.shoonglogitics.userservice.domain.entity.CompanyManager;
+import com.shoonglogitics.userservice.domain.entity.HubManager;
+import com.shoonglogitics.userservice.domain.entity.Shipper;
 import com.shoonglogitics.userservice.domain.entity.User;
+import com.shoonglogitics.userservice.domain.vo.HubId;
 
 public interface UserRepository {
 
@@ -40,4 +45,12 @@ public interface UserRepository {
 	Optional<ShipperViewResponseDto> findShipperById(Long id);
 
 	Optional<CompanyManagerViewResponseDto> findCompanyManagerById(Long id);
+
+	Optional<Integer> findLastShipperOrderByHubId(HubId hubId);
+
+	List<HubManager> findHubManagersByHubId(UUID hubId);
+
+	List<Shipper> findShippersByHubId(UUID hubId);
+
+	List<CompanyManager> findCompanyManagersByCompanyId(UUID companyId);
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/auditing/AuditorAwareImpl.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/auditing/AuditorAwareImpl.java
@@ -7,7 +7,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Component
+@Slf4j
 public class AuditorAwareImpl implements AuditorAware<Long> {
 
 	@Override
@@ -22,6 +25,8 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
 			String userId = (String)authentication.getPrincipal();
 			return Optional.of(Long.parseLong(userId));
 		} catch (Exception e) {
+			log.error("현재 감사자 정보를 SecurityContext에서 가져오는데 실패했습니다. Principal : {}, "
+				+ "에외 메세지 : {}", authentication.getPrincipal(), e.getMessage(), e);
 			return Optional.empty();
 		}
 	}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/auditing/AuditorAwareImpl.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/auditing/AuditorAwareImpl.java
@@ -1,0 +1,28 @@
+package com.shoonglogitics.userservice.infrastructure.auditing;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<Long> {
+
+	@Override
+	public Optional<Long> getCurrentAuditor() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return Optional.empty();
+		}
+
+		try {
+			String userId = (String)authentication.getPrincipal();
+			return Optional.of(Long.parseLong(userId));
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/BaseUserResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/BaseUserResponse.java
@@ -1,0 +1,44 @@
+package com.shoonglogitics.userservice.infrastructure.client.response;
+
+import java.time.LocalDateTime;
+
+import com.shoonglogitics.userservice.domain.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BaseUserResponse {
+
+	private Long userId;
+	private String userName;
+	private String userRole;
+	private String signupStatus;
+
+	private LocalDateTime createdAt;
+	private Long createdBy;
+	private LocalDateTime updatedAt;
+	private Long updatedBy;
+	private LocalDateTime deletedAt;
+	private Long deletedBy;
+
+	public static BaseUserResponse from(User user) {
+		return BaseUserResponse.builder()
+			.userId(user.getId())
+			.userName(user.getUserName())
+			.userRole(user.getUserRole().name())
+			.signupStatus(user.getSignupStatus().name())
+			.createdAt(user.getCreatedAt())
+			.createdBy(user.getCreatedBy())
+			.updatedAt(user.getUpdatedAt())
+			.updatedBy(user.getUpdatedBy())
+			.deletedAt(user.getDeletedAt())
+			.deletedBy(user.getDeletedBy())
+			.build();
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/CompanyManagerResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/CompanyManagerResponse.java
@@ -1,0 +1,46 @@
+package com.shoonglogitics.userservice.infrastructure.client.response;
+
+import java.util.UUID;
+
+import com.shoonglogitics.userservice.domain.entity.CompanyManager;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyManagerResponse extends BaseUserResponse {
+
+	private UUID companyId;
+	private String email;
+	private String name;
+	private String phoneNumber;
+	private String slackId;
+
+	public static CompanyManagerResponse from(CompanyManager companyManager) {
+		return CompanyManagerResponse.builder()
+			.userId(companyManager.getId())
+			.userName(companyManager.getUserName())
+			.userRole(companyManager.getUserRole().name())
+			.signupStatus(companyManager.getSignupStatus().name())
+
+			.companyId(companyManager.getCompanyId().getId())
+			.email(companyManager.getEmail().getValue())
+			.name(companyManager.getName().getValue())
+			.phoneNumber(companyManager.getPhoneNumber().getValue())
+			.slackId(companyManager.getSlackId().getValue())
+
+			.createdAt(companyManager.getCreatedAt())
+			.createdBy(companyManager.getCreatedBy())
+			.updatedAt(companyManager.getUpdatedAt())
+			.updatedBy(companyManager.getUpdatedBy())
+			.deletedAt(companyManager.getDeletedAt())
+			.deletedBy(companyManager.getDeletedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/HubManagerResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/HubManagerResponse.java
@@ -1,0 +1,47 @@
+package com.shoonglogitics.userservice.infrastructure.client.response;
+
+import java.util.UUID;
+
+import com.shoonglogitics.userservice.domain.entity.HubManager;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HubManagerResponse extends BaseUserResponse {
+
+	private UUID hubId;
+	private String email;
+	private String name;
+	private String phoneNumber;
+	private String slackId;
+
+	public static HubManagerResponse from(HubManager hubManager) {
+		return HubManagerResponse.builder()
+			.userId(hubManager.getId())
+			.userName(hubManager.getUserName())
+			.userRole(hubManager.getUserRole().name())
+			.signupStatus(hubManager.getSignupStatus().name())
+
+			.hubId(hubManager.getHubId().getId())
+			.email(hubManager.getEmail().getValue())
+			.name(hubManager.getName().getValue())
+			.phoneNumber(hubManager.getPhoneNumber().getValue())
+			.slackId(hubManager.getSlackId().getValue())
+			.deletedAt(hubManager.getDeletedAt())
+
+			.createdAt(hubManager.getCreatedAt())
+			.createdBy(hubManager.getCreatedBy())
+			.updatedAt(hubManager.getUpdatedAt())
+			.updatedBy(hubManager.getUpdatedBy())
+			.deletedAt(hubManager.getDeletedAt())
+			.deletedBy(hubManager.getDeletedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/ShipperResponse.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/client/response/ShipperResponse.java
@@ -1,0 +1,53 @@
+package com.shoonglogitics.userservice.infrastructure.client.response;
+
+import java.util.UUID;
+
+import com.shoonglogitics.userservice.domain.entity.Shipper;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShipperResponse extends BaseUserResponse {
+
+	private UUID hubId;
+	private String email;
+	private String name;
+	private String phoneNumber;
+	private String slackId;
+	private String shipperType;
+	private Integer order;
+	private Boolean isShippingAvailable;
+
+	public static ShipperResponse from(Shipper shipper) {
+		return ShipperResponse.builder()
+			.userId(shipper.getId())
+			.userName(shipper.getUserName())
+			.userRole(shipper.getUserRole().name())
+			.signupStatus(shipper.getSignupStatus().name())
+
+			.hubId(shipper.getHubId() != null ? shipper.getHubId().getId() : null)
+			.email(shipper.getEmail().getValue())
+			.name(shipper.getName().getValue())
+			.phoneNumber(shipper.getPhoneNumber().getValue())
+			.slackId(shipper.getSlackId().getValue())
+			.shipperType(shipper.getShipperType().name())
+			.order(shipper.getOrder())
+			.isShippingAvailable(shipper.getIsShippingAvailable())
+			.deletedAt(shipper.getDeletedAt())
+
+			.createdAt(shipper.getCreatedAt())
+			.createdBy(shipper.getCreatedBy())
+			.updatedAt(shipper.getUpdatedAt())
+			.updatedBy(shipper.getUpdatedBy())
+			.deletedAt(shipper.getDeletedAt())
+			.deletedBy(shipper.getDeletedBy())
+			.build();
+	}
+
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/filter/GatewayAuthenticationFilter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/filter/GatewayAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.shoonglogitics.userservice.infrastructure.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class GatewayAuthenticationFilter extends OncePerRequestFilter {
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final String USER_ROLE_HEADER = "X-User-Role";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String userId = request.getHeader(USER_ID_HEADER);
+		String role = request.getHeader(USER_ROLE_HEADER);
+
+		if (userId != null && role != null) {
+			try {
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(
+						userId,  // principal
+						null,    // credentials
+						List.of(new SimpleGrantedAuthority("ROLE_" + role))  // authorities
+					);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+
+			} catch (Exception e) {
+				log.error("인증 정보가 없습니다.");
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/JpaUserRepository.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.infrastructure.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,7 +15,11 @@ import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponse
 import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
 import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
 import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
+import com.shoonglogitics.userservice.domain.entity.CompanyManager;
+import com.shoonglogitics.userservice.domain.entity.HubManager;
+import com.shoonglogitics.userservice.domain.entity.Shipper;
 import com.shoonglogitics.userservice.domain.entity.User;
+import com.shoonglogitics.userservice.domain.vo.HubId;
 
 @Repository
 public interface JpaUserRepository extends JpaRepository<User, Long> {
@@ -139,5 +144,17 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 		    from CompanyManager c where c.id = :id
 		""")
 	Optional<CompanyManagerViewResponseDto> findCompanyManagerById(@Param("id") Long id);
+
+	@Query("SELECT MAX(s.order) FROM Shipper s WHERE s.hubId = :hubId")
+	Optional<Integer> findLastShipperOrderByHubId(@Param("hubId") HubId hubId);
+
+	@Query("SELECT u FROM HubManager u WHERE u.hubId.id = :hubId AND u.deletedAt IS NULL")
+	List<HubManager> findHubManagersByHubId(@Param("hubId") UUID hubId);
+
+	@Query("SELECT u FROM Shipper u WHERE u.hubId.id = :hubId AND u.deletedAt IS NULL")
+	List<Shipper> findShippersByHubId(@Param("hubId") UUID hubId);
+
+	@Query("SELECT u FROM CompanyManager u WHERE u.companyId.id = :companyId AND u.deletedAt IS NULL")
+	List<CompanyManager> findCompanyManagersByCompanyId(@Param("companyId") UUID companyId);
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/infrastructure/repository/UserRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.infrastructure.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,8 +12,12 @@ import com.shoonglogitics.userservice.application.dto.CompanyManagerViewResponse
 import com.shoonglogitics.userservice.application.dto.HubManagerViewResponseDto;
 import com.shoonglogitics.userservice.application.dto.MasterViewResponseDto;
 import com.shoonglogitics.userservice.application.dto.ShipperViewResponseDto;
+import com.shoonglogitics.userservice.domain.entity.CompanyManager;
+import com.shoonglogitics.userservice.domain.entity.HubManager;
+import com.shoonglogitics.userservice.domain.entity.Shipper;
 import com.shoonglogitics.userservice.domain.entity.User;
 import com.shoonglogitics.userservice.domain.repository.UserRepository;
+import com.shoonglogitics.userservice.domain.vo.HubId;
 
 import lombok.RequiredArgsConstructor;
 
@@ -85,6 +90,26 @@ public class UserRepositoryAdapter implements UserRepository {
 	@Override
 	public Optional<CompanyManagerViewResponseDto> findCompanyManagerById(Long id) {
 		return jpaUserRepository.findCompanyManagerById(id);
+	}
+
+	@Override
+	public Optional<Integer> findLastShipperOrderByHubId(HubId hubId) {
+		return jpaUserRepository.findLastShipperOrderByHubId(hubId);
+	}
+
+	@Override
+	public List<HubManager> findHubManagersByHubId(UUID hubId) {
+		return jpaUserRepository.findHubManagersByHubId(hubId);
+	}
+
+	@Override
+	public List<Shipper> findShippersByHubId(UUID hubId) {
+		return jpaUserRepository.findShippersByHubId(hubId);
+	}
+
+	@Override
+	public List<CompanyManager> findCompanyManagersByCompanyId(UUID companyId) {
+		return jpaUserRepository.findCompanyManagersByCompanyId(companyId);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -66,8 +66,8 @@ public class UserController {
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<Void>> loginUser(@RequestBody LoginRequest dto,
 		HttpServletResponse response) {
-		LoginUserCommand from = LoginUserCommand.from(dto);
-		LoginUserResponseDto responseDto = userService.loginUser(from);
+		LoginUserCommand command = dto.toCommand();
+		LoginUserResponseDto responseDto = userService.loginUser(command);
 
 		response.setHeader("Authorization", "Bearer " + responseDto.accessToken());
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.shoonglogitics.userservice.presentation.controller;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,6 +25,7 @@ import com.shoonglogitics.userservice.application.command.SignUpUserCommand;
 import com.shoonglogitics.userservice.application.command.UpdateUserCommand;
 import com.shoonglogitics.userservice.application.dto.LoginUserResponseDto;
 import com.shoonglogitics.userservice.application.dto.PageResponse;
+import com.shoonglogitics.userservice.application.service.InternalUserService;
 import com.shoonglogitics.userservice.application.service.UserService;
 import com.shoonglogitics.userservice.domain.entity.User;
 import com.shoonglogitics.userservice.presentation.dto.ApiResponse;
@@ -32,7 +34,6 @@ import com.shoonglogitics.userservice.presentation.dto.request.SignUpRequest;
 import com.shoonglogitics.userservice.presentation.dto.request.UpdateSignupStatusRequest;
 import com.shoonglogitics.userservice.presentation.dto.request.UpdateUserRequest;
 import com.shoonglogitics.userservice.presentation.dto.response.SignUpResponse;
-import com.shoonglogitics.userservice.security.JwtProvider;
 
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -44,7 +45,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final UserService userService;
-	private final JwtProvider jwtProvider;
+	private final InternalUserService internalUserService;
 
 	// 회원가입
 	@PostMapping("/signup")
@@ -144,6 +145,17 @@ public class UserController {
 
 		userService.deleteUser(id);
 		return ResponseEntity.ok(ApiResponse.success("회원이 성공적으로 삭제 되었습니다."));
+	}
+
+	// internal 회원목록 조회 --> 분리 이유 : MASTER권한이 필요없어야하기 때문에
+	// 검색기준 : 허브Id, 업체Id
+	@GetMapping("/internal")
+	public ResponseEntity<ApiResponse<List<?>>> getFeignClientUsers(
+		@RequestParam(required = false) UUID hubId,
+		@RequestParam(required = false) UUID companyId
+	) {
+		List<?> list = internalUserService.getInternalUsers(hubId, companyId);
+		return ResponseEntity.ok(ApiResponse.success(list));
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -8,6 +8,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -128,6 +129,21 @@ public class UserController {
 		return ResponseEntity.ok(
 			ApiResponse.success("회원 정보가 성공적으로 수정되었습니다.")
 		);
+	}
+
+	// 회원 삭제
+	@DeleteMapping("/{id}")
+	public ResponseEntity<ApiResponse<?>> deleteUser(@RequestHeader("X-User-Role") String role,
+		@RequestHeader("X-User-Id") Long requesterId,
+		@PathVariable Long id) {
+
+		if (!userService.canDeleteUser(role, requesterId, id)) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN)
+				.body(ApiResponse.error("삭제 권한이 없습니다."));
+		}
+
+		userService.deleteUser(id);
+		return ResponseEntity.ok(ApiResponse.success("회원이 성공적으로 삭제 되었습니다."));
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/controller/UserController.java
@@ -1,13 +1,9 @@
 package com.shoonglogitics.userservice.presentation.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -88,24 +84,8 @@ public class UserController {
 		@RequestParam(defaultValue = "createdAt") List<String> sortBy,
 		@RequestParam(defaultValue = "DESC") List<String> direction) {
 
-		List<Sort.Order> orders = new ArrayList<>();
-		for (int i = 0; i < sortBy.size(); i++) {
-			String sortField = sortBy.get(i);
-			String sortDirection = (i < direction.size()) ? direction.get(i) : "DESC";
-			Sort.Order order = sortDirection.equalsIgnoreCase("ASC") ?
-				Sort.Order.asc(sortField) :
-				Sort.Order.desc(sortField);
-
-			orders.add(order);
-		}
-
-		Sort sort = Sort.by(orders);
-
-		Pageable pageable = PageRequest.of(page, pageSizeType.getValue(), sort);
-
-		PageResponse<Object> users = userService.getUsers(role, pageable, hubId);
-
-		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(users));
+		PageResponse<?> users = userService.getUsers(role, page, pageSizeType, sortBy, direction, hubId);
+		return ResponseEntity.ok(ApiResponse.success(users));
 	}
 
 	// 회원 단건 조회

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/HubManagerSignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/HubManagerSignUpRequest.java
@@ -1,5 +1,7 @@
 package com.shoonglogitics.userservice.presentation.dto.request;
 
+import java.util.UUID;
+
 import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
 import com.shoonglogitics.userservice.domain.vo.Email;
 import com.shoonglogitics.userservice.domain.vo.HubId;
@@ -13,7 +15,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class HubManagerSignUpRequest extends SignUpRequest {
-	private HubId hubId;
+	private String hubId;
 
 	@Override
 	public HubManagerSignUpCommand toCommand() {
@@ -24,7 +26,7 @@ public class HubManagerSignUpRequest extends SignUpRequest {
 			.name(new Name(getName()))
 			.slackId(new SlackId(getSlackId()))
 			.phoneNumber(new PhoneNumber(getPhoneNumber()))
-			.hubId(hubId)
+			.hubId(new HubId(UUID.fromString(hubId)))
 			.build();
 	}
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/LoginRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/LoginRequest.java
@@ -2,10 +2,18 @@ package com.shoonglogitics.userservice.presentation.dto.request;
 
 import com.shoonglogitics.userservice.application.command.LoginUserCommand;
 
-public record LoginRequest(String userName, String password) {
+import jakarta.validation.constraints.NotBlank;
 
-	public static LoginUserCommand from(LoginRequest dto) {
-		return new LoginUserCommand(dto.userName(), dto.password());
+public record LoginRequest(
+
+	@NotBlank(message = "사용자 이름은 필수입니다.")
+	String userName,
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	String password) {
+
+	public LoginUserCommand toCommand() {
+		return new LoginUserCommand(userName, password);
 	}
 
 }

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/LoginRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/LoginRequest.java
@@ -2,9 +2,9 @@ package com.shoonglogitics.userservice.presentation.dto.request;
 
 import com.shoonglogitics.userservice.application.command.LoginUserCommand;
 
-public record LoginRequestDto(String userName, String password) {
+public record LoginRequest(String userName, String password) {
 
-	public static LoginUserCommand from(LoginRequestDto dto) {
+	public static LoginUserCommand from(LoginRequest dto) {
 		return new LoginUserCommand(dto.userName(), dto.password());
 	}
 

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/PageSizeType.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/PageSizeType.java
@@ -1,0 +1,16 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public enum PageSizeType {
+	SIZE_10(10),
+	SIZE_30(30),
+	SIZE_50(50);
+
+	private final int value;
+
+	PageSizeType(int value) {
+		this.value = value;
+	}
+}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/ShipperSignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/ShipperSignUpRequest.java
@@ -1,5 +1,7 @@
 package com.shoonglogitics.userservice.presentation.dto.request;
 
+import java.util.UUID;
+
 import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
 import com.shoonglogitics.userservice.domain.entity.ShipperType;
 import com.shoonglogitics.userservice.domain.vo.Email;
@@ -14,9 +16,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ShipperSignUpRequest extends SignUpRequest {
-	private HubId hubId;
+	private String hubId;
 	private ShipperType shipperType;
-	private Integer order;
 	private Boolean isShippingAvailable;
 
 	@Override
@@ -28,9 +29,8 @@ public class ShipperSignUpRequest extends SignUpRequest {
 			.name(new Name(getName()))
 			.slackId(new SlackId(getSlackId()))
 			.phoneNumber(new PhoneNumber(getPhoneNumber()))
-			.hubId(hubId != null ? hubId : null)
+			.hubId(hubId != null ? new HubId(UUID.fromString(hubId)) : null)
 			.shipperType(shipperType)
-			.order(order)
 			.isShippingAvailable(isShippingAvailable)
 			.build();
 	}

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
@@ -3,8 +3,9 @@ package com.shoonglogitics.userservice.presentation.dto.request;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -21,20 +22,28 @@ import lombok.Getter;
 })
 public abstract class SignUpRequest {
 
-	@Size(min = 4, max = 10, message = "아이디는 4~10자이어야 합니다.")
+	@NotBlank(message = "아이디 값은 필수입니다.")
 	@Pattern(regexp = "^[a-z0-9]{4,10}$",
 		message = "아이디는 소문자(a~z)와 숫자(0~9)만 사용 가능합니다.")
 	private String userName;
 
-	@Size(min = 8, max = 15, message = "비밀번호는 8~15자리이어야 합니다.")
+	@NotBlank(message = "비밀번호 값은 필수입니다.")
 	@Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
 		message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 포함해야합니다.")
 
 	private String password;
 
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
 	private String email;
+
+	@NotBlank(message = "이름은 필수입니다.")
 	private String name;
+
+	@NotBlank(message = "Slack ID는 필수입니다.")
 	private String slackId;
+
+	@NotBlank(message = "전화번호는 필수입니다.")
 	private String phoneNumber;
 
 	public abstract <T> T toCommand();

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/SignUpRequest.java
@@ -3,6 +3,8 @@ package com.shoonglogitics.userservice.presentation.dto.request;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -19,7 +21,15 @@ import lombok.Getter;
 })
 public abstract class SignUpRequest {
 
+	@Size(min = 4, max = 10, message = "아이디는 4~10자이어야 합니다.")
+	@Pattern(regexp = "^[a-z0-9]{4,10}$",
+		message = "아이디는 소문자(a~z)와 숫자(0~9)만 사용 가능합니다.")
 	private String userName;
+
+	@Size(min = 8, max = 15, message = "비밀번호는 8~15자리이어야 합니다.")
+	@Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+		message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 포함해야합니다.")
+
 	private String password;
 
 	private String email;

--- a/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/UpdateUserRequest.java
+++ b/user-service/src/main/java/com/shoonglogitics/userservice/presentation/dto/request/UpdateUserRequest.java
@@ -1,0 +1,23 @@
+package com.shoonglogitics.userservice.presentation.dto.request;
+
+import com.shoonglogitics.userservice.application.command.UpdateUserCommand;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserRequest {
+
+	private String name;
+	private String email;
+	private String slackId;
+	private String phoneNumber;
+
+	public UpdateUserCommand toCommand() {
+		return new UpdateUserCommand(name, email, slackId, phoneNumber);
+	}
+
+}

--- a/user-service/src/main/resources/application-datasource.yml
+++ b/user-service/src/main/resources/application-datasource.yml
@@ -6,7 +6,7 @@ spring:
     url: jdbc:postgresql://localhost:5432/user_service
     driver-class-name: org.postgresql.Driver
     username: postgres
-    password: qwer1234!
+    password: brian981103
 
   jpa:
     hibernate:
@@ -16,7 +16,7 @@ spring:
         format_sql: false
         show_sql: false
         use_sql_comments: false
-    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
 
 logging:
   level:
@@ -42,7 +42,7 @@ spring:
         format_sql: false
         show_sql: false
         use_sql_comments: false
-        database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
 
 logging:
   level:
@@ -68,7 +68,7 @@ spring:
         format_sql: false
         show_sql: false
         use_sql_comments: false
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 logging:
   level:
@@ -94,7 +94,7 @@ spring:
         format_sql: false
         show_sql: false
         use_sql_comments: false
-    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
 
 logging:
   level:

--- a/user-service/src/main/resources/application-datasource.yml
+++ b/user-service/src/main/resources/application-datasource.yml
@@ -1,0 +1,101 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:postgresql://localhost:5432/user_service
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: qwer1234!
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5432/user_service
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: qwer1234!
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+        database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:postgresql://localhost:5432/user_service
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: qwer1234!
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    driver-class-name: org.postgresql.Driver
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+        use_sql_comments: false
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
+
+logging:
+  level:
+    org.hibernate: warn

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,27 +1,12 @@
+server:
+  port: 8081
+
 spring:
-  application:
-    name: user-service
-
-  datasource:
-    url: jdbc:mysql://localhost:3306/userDB?useSSL=false&serverTimezone=Asia/Seoul
-    username: root
-    password: brian981103
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: create
-
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
+  profiles:
+    include:
+      - datasource
 
 # TODO : configure-service? ??
 jwt:
   secret: "sdfu2893rwefsd8f7sdf9832fsd9f7sdf9832fsd9f7sdf9832fsd9f7sdf9832fsd9f7sdf9832fsd9f7sdf9832f"
   expiration: 3600000
-
-server:
-  port: 8081

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
   profiles:
     include:
       - datasource
+    active: test
 
 # TODO : configure-service? ??
 jwt:

--- a/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
+++ b/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
@@ -131,7 +131,6 @@ class UserServiceTest {
 			.hubId(new HubId(UUID.randomUUID()))
 			.slackId(new SlackId("ShipperSlack1"))
 			.phoneNumber(new PhoneNumber("010-4444-5555"))
-			.order(1)
 			.isShippingAvailable(true)
 			.shipperType(ShipperType.COMPANY_SHIPPER)
 			.build();
@@ -160,7 +159,6 @@ class UserServiceTest {
 			.phoneNumber(new PhoneNumber("010-1111-2222"))
 			.shipperType(ShipperType.COMPANY_SHIPPER)
 			.hubId(null) // hubId 누락
-			.order(1)
 			.isShippingAvailable(true)
 			.build();
 
@@ -181,7 +179,6 @@ class UserServiceTest {
 			.phoneNumber(new PhoneNumber("010-2222-3333"))
 			.shipperType(ShipperType.HUB_SHIPPER)
 			.hubId(new HubId(UUID.randomUUID())) // hubId 존재 → 예외
-			.order(1)
 			.isShippingAvailable(true)
 			.build();
 

--- a/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
+++ b/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
@@ -10,10 +10,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.shoonglogitics.userservice.UserServiceApplication;
 import com.shoonglogitics.userservice.application.command.CompanyManagerSignUpCommand;
 import com.shoonglogitics.userservice.application.command.HubManagerSignUpCommand;
 import com.shoonglogitics.userservice.application.command.MasterSignUpCommand;
 import com.shoonglogitics.userservice.application.command.ShipperSignUpCommand;
+import com.shoonglogitics.userservice.application.command.UpdateUserCommand;
 import com.shoonglogitics.userservice.domain.entity.CompanyManager;
 import com.shoonglogitics.userservice.domain.entity.HubManager;
 import com.shoonglogitics.userservice.domain.entity.Master;
@@ -32,7 +34,7 @@ import com.shoonglogitics.userservice.domain.vo.SlackId;
 
 import jakarta.persistence.EntityManager;
 
-@SpringBootTest
+@SpringBootTest(classes = UserServiceApplication.class)
 @Transactional
 class UserServiceTest {
 
@@ -214,4 +216,171 @@ class UserServiceTest {
 		User updatedUser = userRepository.findByUsername("master1").orElseThrow();
 		assertThat(updatedUser.getSignupStatus()).isEqualTo(SignupStatus.APPROVED);
 	}
+
+	//====================================================================
+	@Test
+	@DisplayName("updateSignupStatus - 지원하지 않는 상태값이면 예외 발생")
+	void updateSignupStatus_invalidStatus_throwsException() {
+		MasterSignUpCommand command = MasterSignUpCommand.builder()
+			.userName("master2")
+			.password("12345678")
+			.email(new Email("master2@gmail.com"))
+			.name(new Name("테스트"))
+			.slackId(new SlackId("Slack2"))
+			.phoneNumber(new PhoneNumber("010-5555-6666"))
+			.build();
+
+		userService.signUp(command);
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("master2").orElseThrow();
+
+		assertThatThrownBy(() -> userService.updateSignupStatus(user.getId(), "UNKNOWN"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("지원하지 않는 상태값입니다");
+	}
+
+	@Test
+	@DisplayName("updateUser - Master 타입이면 정보 수정")
+	void updateUser_success() {
+		// given: Master 생성
+		MasterSignUpCommand command = MasterSignUpCommand.builder()
+			.userName("master3")
+			.password("12345678")
+			.email(new Email("master3@gmail.com"))
+			.name(new Name("업데이트 전"))
+			.slackId(new SlackId("Slack3"))
+			.phoneNumber(new PhoneNumber("010-7777-8888"))
+			.build();
+
+		userService.signUp(command);
+		em.flush();
+		em.clear();
+
+		Master master = (Master)userRepository.findByUsername("master3").orElseThrow();
+
+		// when: 정보 수정
+		UpdateUserCommand updateCommand = new UpdateUserCommand(
+			"업데이트 후",
+			"updated3@gmail.com",
+			"UpdatedSlack",
+			"010-9999-0000"
+		);
+
+		userService.updateUser(master.getId(), updateCommand);
+		em.flush();
+		em.clear();
+
+		// then: 값 검증
+		Master updatedMaster = (Master)userRepository.findByUsername("master3").orElseThrow();
+		assertThat(updatedMaster.getName().getValue()).isEqualTo("업데이트 후");
+		assertThat(updatedMaster.getEmail().getValue()).isEqualTo("updated3@gmail.com");
+		assertThat(updatedMaster.getSlackId().getValue()).isEqualTo("UpdatedSlack");
+		assertThat(updatedMaster.getPhoneNumber().getValue()).isEqualTo("010-9999-0000");
+	}
+
+	@Test
+	@DisplayName("deleteUser - 정상 삭제")
+	void deleteUser_success() {
+		MasterSignUpCommand command = MasterSignUpCommand.builder()
+			.userName("master4")
+			.password("12345678")
+			.email(new Email("master4@gmail.com"))
+			.name(new Name("삭제 전"))
+			.slackId(new SlackId("Slack4"))
+			.phoneNumber(new PhoneNumber("010-1234-5678"))
+			.build();
+
+		userService.signUp(command);
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("master4").orElseThrow();
+
+		userService.deleteUser(user.getId());
+		em.flush();
+		em.clear();
+
+		User deletedUser = userRepository.findByUsername("master4").orElseThrow();
+		assertThat(deletedUser.isDeleted()).isTrue();
+	}
+
+	@Test
+	@DisplayName("deleteUser - 이미 삭제된 사용자면 예외 발생")
+	void deleteUser_alreadyDeleted_throwsException() {
+		MasterSignUpCommand command = MasterSignUpCommand.builder()
+			.userName("master5")
+			.password("12345678")
+			.email(new Email("master5@gmail.com"))
+			.name(new Name("삭제 예외"))
+			.slackId(new SlackId("Slack5"))
+			.phoneNumber(new PhoneNumber("010-2345-6789"))
+			.build();
+
+		userService.signUp(command);
+		em.flush();
+		em.clear();
+
+		User user = userRepository.findByUsername("master5").orElseThrow();
+		user.softDelete(user.getId());
+		em.flush();
+		em.clear();
+
+		assertThatThrownBy(() -> userService.deleteUser(user.getId()))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("이미 삭제된 사용자입니다.");
+	}
+
+	@Test
+	@DisplayName("canUpdateUser / canDeleteUser 권한 체크 - MASTER 항상 true")
+	void canUpdateAndDelete_master() {
+		assertThat(userService.canUpdateUser("MASTER", 1L, 2L)).isTrue();
+		assertThat(userService.canDeleteUser("MASTER", 1L, 2L)).isTrue();
+	}
+
+	@Test
+	@DisplayName("canUpdateUser / canDeleteUser 권한 체크 - HUB_MANAGER 제한 확인")
+	void canUpdateAndDelete_hubManager() {
+		// HubManager 생성 및 hubId 동일/다른 경우 테스트
+		UUID hubId1 = UUID.randomUUID();
+		HubManager manager = HubManager.builder()
+			.userName("hubManager")
+			.password("12345678")
+			.hubId(new HubId(hubId1))
+			.signupStatus(SignupStatus.PENDING)
+			.userRole(UserRole.HUB_MANAGER)
+			.build();
+		userRepository.save(manager);
+
+		HubManager targetManagerSameHub = HubManager.builder()
+			.userName("hubTarget1")
+			.password("12345678")
+			.hubId(new HubId(hubId1))
+			.signupStatus(SignupStatus.PENDING)
+			.userRole(UserRole.HUB_MANAGER)
+			.build();
+		userRepository.save(targetManagerSameHub);
+
+		HubManager targetManagerDiffHub = HubManager.builder()
+			.userName("hubTarget2")
+			.password("12345678")
+			.hubId(new HubId(UUID.randomUUID()))
+			.signupStatus(SignupStatus.PENDING)
+			.userRole(UserRole.HUB_MANAGER)
+			.build();
+		userRepository.save(targetManagerDiffHub);
+
+		em.flush();
+		em.clear();
+
+		// 같은 허브면 true
+		assertThat(userService.canUpdateUser("HUB_MANAGER", manager.getId(), targetManagerSameHub.getId())).isTrue();
+		assertThat(userService.canDeleteUser("HUB_MANAGER", manager.getId(), targetManagerSameHub.getId())).isTrue();
+
+		// 다른 허브면 false
+		assertThat(userService.canUpdateUser("HUB_MANAGER", manager.getId(), targetManagerDiffHub.getId())).isFalse();
+		assertThat(userService.canDeleteUser("HUB_MANAGER", manager.getId(), targetManagerDiffHub.getId())).isFalse();
+	}
+
 }

--- a/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
+++ b/user-service/src/test/java/com/shoonglogitics/userservice/application/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.shoonglogitics.userservice.UserServiceApplication;
@@ -36,6 +37,7 @@ import jakarta.persistence.EntityManager;
 
 @SpringBootTest(classes = UserServiceApplication.class)
 @Transactional
+@Profile(value = "test")
 class UserServiceTest {
 
 	@Autowired

--- a/user-service/src/test/java/com/shoonglogitics/userservice/domain/entity/DomainTest.java
+++ b/user-service/src/test/java/com/shoonglogitics/userservice/domain/entity/DomainTest.java
@@ -1,0 +1,192 @@
+package com.shoonglogitics.userservice.domain.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.shoonglogitics.userservice.domain.vo.Email;
+import com.shoonglogitics.userservice.domain.vo.Name;
+import com.shoonglogitics.userservice.domain.vo.PhoneNumber;
+import com.shoonglogitics.userservice.domain.vo.SlackId;
+
+class DomainTest {
+
+	@Test
+	@DisplayName("정상적인 회원 생성 테스트")
+	void createUser_success() {
+		String userName = "brian123";
+		String password = "Brian981103!";
+
+		User user = User.create(userName, password, UserRole.MASTER);
+
+		assertThat(user.getUserName()).isEqualTo(userName);
+		assertThat(user.getPassword()).isEqualTo(password);
+		assertThat(user.getUserRole()).isEqualTo(UserRole.MASTER);
+		assertThat(user.getSignupStatus()).isEqualTo(SignupStatus.PENDING);
+	}
+
+	@Test
+	@DisplayName("아이디가 null이면 예외발생")
+	void createUser_nullUserName_throwsException() {
+		// given
+		String userName = null;
+		String password = "Brian981103!";
+
+		// when & then
+		assertThatThrownBy(() -> User.create(userName, password, UserRole.MASTER))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("아이디 값은 필수입니다.");
+	}
+
+	@Test
+	@DisplayName("아이디 길이가 4자 미만이면 예외 발생")
+	void createUser_shortUserName_throwsException() {
+		// given
+		String userName = "abc";
+		String password = "Brian981103!";
+
+		// when & then
+		assertThatThrownBy(() -> User.create(userName, password, UserRole.MASTER))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("아이디는 4자 이상 10자 이하이어야 합니다.");
+	}
+
+	@Test
+	@DisplayName("비밀번호가 null이면 예외 발생")
+	void createUser_nullPassword_throwsException() {
+		// given
+		String userName = "brian123";
+		String password = null;
+
+		// when & then
+		assertThatThrownBy(() -> User.create(userName, password, UserRole.MASTER))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("비밀번호 값은 필수입니다.");
+	}
+
+	@Test
+	@DisplayName("비밀번호 길이가 8자 미만이면 예외 발생")
+	void createUser_shortPassword_throwsException() {
+		// given
+		String userName = "brian123";
+		String password = "short";
+
+		// when & then
+		assertThatThrownBy(() -> User.create(userName, password, UserRole.MASTER))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("비밀번호는 8자 이상 15자 이하이어야 합니다.");
+	}
+
+	@Test
+	@DisplayName("회원 승인 테스트")
+	void approveSignup_success() {
+		// given
+		User user = User.create("brian123", "Brian981103!", UserRole.MASTER);
+
+		// when
+		user.approveSignup();
+
+		// then
+		assertThat(user.getSignupStatus()).isEqualTo(SignupStatus.APPROVED);
+	}
+
+	@Test
+	@DisplayName("승인 상태가 아닌 경우 승인 시 예외 발생")
+	void approveSignup_invalidState_throwsException() {
+		// given
+		User user = User.create("brian123", "Brian981103!", UserRole.MASTER);
+		user.approveSignup(); // 이미 APPROVED 상태
+
+		// when & then
+		assertThatThrownBy(user::approveSignup)
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("승인할 수 없는 상태입니다.");
+	}
+
+	@Test
+	@DisplayName("필수 값이 null이면 예외 발생 테스트")
+	void createMaster_nullVO_throwsException() {
+		String userName = "master1";
+		String password = "password1";
+		Email email = null;
+		Name name = null;
+		SlackId slackId = null;
+		PhoneNumber phoneNumber = null;
+
+		// when & then
+		assertThatThrownBy(() -> Master.create(userName, password, email, new Name("Name"),
+			new SlackId("slack"), new PhoneNumber("01012345678")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이메일은 필수 값입니다.");
+
+		assertThatThrownBy(() -> Master.create(userName, password, new Email("email@example.com"),
+			null, new SlackId("slack"), new PhoneNumber("01012345678")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이름은 필수 값입니다.");
+
+		assertThatThrownBy(() -> Master.create(userName, password, new Email("email@example.com"),
+			new Name("Name"), null, new PhoneNumber("01012345678")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Slack ID는 필수 값입니다.");
+
+		assertThatThrownBy(() -> Master.create(userName, password, new Email("email@example.com"),
+			new Name("Name"), new SlackId("slack"), null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("전화번호는 필수 값입니다.");
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 테스트")
+	void updateUserInfo_success() {
+		// given
+		Master master = Master.create(
+			"master1",
+			"Brian981103!",
+			new Email("master@example.com"),
+			new Name("Master Name"),
+			new SlackId("master_slack"),
+			new PhoneNumber("01012345678")
+		);
+
+		Name newName = new Name("Updated Name");
+		Email newEmail = new Email("updated@example.com");
+		SlackId newSlackId = new SlackId("updated_slack");
+		PhoneNumber newPhoneNumber = new PhoneNumber("01087654321");
+
+		// when
+		master.updateUserInfo(newName, newEmail, newSlackId, newPhoneNumber);
+
+		// then
+		assertThat(master.getName()).isEqualTo(newName);
+		assertThat(master.getEmail()).isEqualTo(newEmail);
+		assertThat(master.getSlackId()).isEqualTo(newSlackId);
+		assertThat(master.getPhoneNumber()).isEqualTo(newPhoneNumber);
+	}
+
+	@Test
+	@DisplayName("정상적인 Master 생성 테스트")
+	void createMaster_success() {
+		// given
+		String userName = "master1";
+		String password = "Brian981103!";
+		Email email = new Email("master@example.com");
+		Name name = new Name("Master Name");
+		SlackId slackId = new SlackId("master_slack");
+		PhoneNumber phoneNumber = new PhoneNumber("01012345678");
+
+		// when
+		Master master = Master.create(userName, password, email, name, slackId, phoneNumber);
+
+		// then
+		assertThat(master.getUserName()).isEqualTo(userName);
+		assertThat(master.getPassword()).isEqualTo(password);
+		assertThat(master.getUserRole()).isEqualTo(UserRole.MASTER);
+		assertThat(master.getSignupStatus()).isEqualTo(SignupStatus.PENDING);
+		assertThat(master.getEmail()).isEqualTo(email);
+		assertThat(master.getName()).isEqualTo(name);
+		assertThat(master.getSlackId()).isEqualTo(slackId);
+		assertThat(master.getPhoneNumber()).isEqualTo(phoneNumber);
+	}
+
+}


### PR DESCRIPTION
### 연관이슈(#7 )

### 변경사항
- 감사기능 추가(BaseAggregateRoot가 아닌 BaseEntity를 상속받음)
- 회원 수정 기능
- 회원 삭제 기능
- 배송담당자 회원가입시 마지막 번호 자동 부여로 수정
- hubId, companyId의 기준에 따른 회원목록 조회 기능(FeignClient용)
- mysql등 테스트용 DB 의존성을 삭제하고 postgres로 변경
- application.yml을 profile 별로 구분

### 리뷰요청
- 이전에 올렸던 기능이지만 로그인은 PENDING이 아닌 APPROVED가 된 상태여야 로그인이 가능합니다. 현재 모든 권한의 관리자들이 회원가입 시 자동으로 PENDING이 되는데 이 status를 바꿀 수 있는 MASTER, HUB_MANAGER는 회원가입 시 바로 APPROVED로 고정시킬까 고민입니다.(실제로 테스트할 때 회원가입 후 데이터베이스에서 직접 APPROVED로 수정했기 때문에 번거로움이 있음)

- commit 중 8dac1cf 부분은 안보셔도 됩니다. 목록 조회 시 정렬 조건을 적용하는 코드를 서비스에 작성해야하는데 컨트롤러에 작성하게 되어 옮기기만 했습니다. 그 commit이 아래에 있는 43e5475입니다.