### PR TITLE
[feat] 업체 상세/목록 조회 API 구현

### DIFF
--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/CompanyService.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/CompanyService.java
@@ -2,10 +2,12 @@ package com.shoonglogitics.companyservice.application;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.shoonglogitics.companyservice.application.command.CreateCompanyCommand;
+import com.shoonglogitics.companyservice.application.command.GetCompaniesCommand;
 import com.shoonglogitics.companyservice.application.dto.CompanyResult;
 import com.shoonglogitics.companyservice.application.service.UserClient;
 import com.shoonglogitics.companyservice.domain.common.vo.GeoLocation;
@@ -41,5 +43,10 @@ public class CompanyService {
 			.orElseThrow(() -> new IllegalArgumentException("업체를 찾을 수 없습니다."));
 		
 		return CompanyResult.from(company);
+	}
+
+	public Page<CompanyResult> getCompanies(GetCompaniesCommand command) {
+		Page<Company> companies = companyRepository.getCompanies(command.hubId(), command.name(), command.type(), command.pageRequest().toPageable());
+		return companies.map(CompanyResult::from);
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/CompanyService.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/CompanyService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.shoonglogitics.companyservice.application.command.CreateCompanyCommand;
+import com.shoonglogitics.companyservice.application.dto.CompanyResult;
 import com.shoonglogitics.companyservice.application.service.UserClient;
 import com.shoonglogitics.companyservice.domain.common.vo.GeoLocation;
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
@@ -33,5 +34,12 @@ public class CompanyService {
 
 		companyRepository.save(company);
 		return company.getId();
+	}
+
+	public CompanyResult getCompany(UUID companyId) {
+		Company company = companyRepository.findById(companyId)
+			.orElseThrow(() -> new IllegalArgumentException("업체를 찾을 수 없습니다."));
+		
+		return CompanyResult.from(company);
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/command/GetCompaniesCommand.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/command/GetCompaniesCommand.java
@@ -1,0 +1,22 @@
+package com.shoonglogitics.companyservice.application.command;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
+import com.shoonglogitics.companyservice.presentation.company.common.dto.PageRequest;
+
+import lombok.Builder;
+
+@Builder
+public record GetCompaniesCommand(
+	UUID hubId,
+	String name,
+	CompanyType type,
+	PageRequest pageRequest
+) {
+	public Pageable getPageable() {
+		return pageRequest.toPageable();
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/application/dto/CompanyResult.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/application/dto/CompanyResult.java
@@ -1,4 +1,37 @@
 package com.shoonglogitics.companyservice.application.dto;
 
-public record CompanyResult() {
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.shoonglogitics.companyservice.domain.company.entity.Company;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
+
+public record CompanyResult(
+	UUID id,
+	UUID hubId,
+	String name,
+	String address,
+	String addressDetail,
+	String zipCode,
+	Double latitude,
+	Double longitude,
+	CompanyType type,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+	public static CompanyResult from(Company company) {
+		return new CompanyResult(
+			company.getId(),
+			company.getHubId(),
+			company.getName(),
+			company.getAddressValue(),
+			company.getAddressDetailValue(),
+			company.getZipCodeValue(),
+			company.getLatitude(),
+			company.getLongitude(),
+			company.getType(),
+			company.getCreatedAt(),
+			company.getUpdatedAt()
+		);
+	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Company.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/entity/Company.java
@@ -85,4 +85,24 @@ public class Company extends BaseAggregateRoot<Company> {
 
 		return company;
 	}
+
+	public Double getLongitude() {
+		return location != null ? location.getLongitude() : null;
+	}
+
+	public Double getLatitude() {
+		return location != null ? location.getLatitude() : null;
+	}
+
+	public String getAddressValue() {
+		return address != null ? address.getAddress() : null;
+	}
+
+	public String getAddressDetailValue() {
+		return address != null ? address.getAddressDetail() : null;
+	}
+
+	public String getZipCodeValue() {
+		return address != null ? address.getZipCode() : null;
+	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/CompanyRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/domain/company/repository/CompanyRepository.java
@@ -3,10 +3,18 @@ package com.shoonglogitics.companyservice.domain.company.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 public interface CompanyRepository {
 	Company save(Company company);
 
 	Optional<Company> findById(UUID id);
+
+	Page<Company> findAll(Pageable pageable);
+
+	Page<Company> getCompanies(UUID hubId, String name, CompanyType type, Pageable pageable);
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/CompanyRepositoryAdapter.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/CompanyRepositoryAdapter.java
@@ -3,10 +3,13 @@ package com.shoonglogitics.companyservice.infrastructure.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
 import com.shoonglogitics.companyservice.domain.company.repository.CompanyRepository;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,5 +26,15 @@ public class CompanyRepositoryAdapter implements CompanyRepository {
 	@Override
 	public Optional<Company> findById(UUID id) {
 		return jpaCompanyRepository.findById(id);
+	}
+
+	@Override
+	public Page<Company> findAll(Pageable pageable) {
+		return jpaCompanyRepository.findAll(pageable);
+	}
+
+	@Override
+	public Page<Company> getCompanies(UUID hubId, String name, CompanyType type, Pageable pageable) {
+		return jpaCompanyRepository.getCompanies(hubId, name, type, pageable);
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaCompanyRepository.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/infrastructure/repository/JpaCompanyRepository.java
@@ -2,11 +2,27 @@ package com.shoonglogitics.companyservice.infrastructure.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.shoonglogitics.companyservice.domain.company.entity.Company;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 
 @Repository
 public interface JpaCompanyRepository extends JpaRepository<Company, UUID> {
+
+	@Query("SELECT c FROM Company c WHERE " +
+		"(:hubId IS NULL OR c.hubId = :hubId) AND " +
+		"(:name IS NULL OR c.name LIKE %:name%) AND " +
+		"(:type IS NULL OR c.type = :type)")
+	Page<Company> getCompanies(
+		@Param("hubId") UUID hubId,
+		@Param("name") String name,
+		@Param("type") CompanyType type,
+		Pageable pageable
+	);
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,8 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.shoonglogitics.companyservice.application.CompanyService;
 import com.shoonglogitics.companyservice.application.command.CreateCompanyCommand;
+import com.shoonglogitics.companyservice.application.dto.CompanyResult;
 import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
 import com.shoonglogitics.companyservice.presentation.company.common.dto.ApiResponse;
+import com.shoonglogitics.companyservice.presentation.company.dto.FindCompanyResponse;
 import com.shoonglogitics.companyservice.presentation.company.dto.CreateCompanyRequest;
 import com.shoonglogitics.companyservice.presentation.company.dto.CreateCompanyResponse;
 
@@ -56,5 +60,16 @@ public class CompanyController {
 		);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	@GetMapping("/{companyId}")
+	@PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER', 'SHIPPER', 'COMPANY_MANAGER')")
+	public ResponseEntity<ApiResponse<FindCompanyResponse>> getCompany(
+		@PathVariable UUID companyId) {
+
+		CompanyResult result = companyService.getCompany(companyId);
+		FindCompanyResponse response = FindCompanyResponse.from(result);
+		
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/CompanyController.java
@@ -2,26 +2,34 @@ package com.shoonglogitics.companyservice.presentation.company;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.shoonglogitics.companyservice.application.CompanyService;
 import com.shoonglogitics.companyservice.application.command.CreateCompanyCommand;
+import com.shoonglogitics.companyservice.application.command.GetCompaniesCommand;
 import com.shoonglogitics.companyservice.application.dto.CompanyResult;
 import com.shoonglogitics.companyservice.domain.common.vo.AuthUser;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
 import com.shoonglogitics.companyservice.presentation.company.common.dto.ApiResponse;
-import com.shoonglogitics.companyservice.presentation.company.dto.FindCompanyResponse;
+import com.shoonglogitics.companyservice.presentation.company.common.dto.PageRequest;
+import com.shoonglogitics.companyservice.presentation.company.common.dto.PageResponse;
 import com.shoonglogitics.companyservice.presentation.company.dto.CreateCompanyRequest;
 import com.shoonglogitics.companyservice.presentation.company.dto.CreateCompanyResponse;
+import com.shoonglogitics.companyservice.presentation.company.dto.FindCompanyResponse;
+import com.shoonglogitics.companyservice.presentation.company.dto.ListCompanyResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +68,26 @@ public class CompanyController {
 		);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	@GetMapping
+	@PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER', 'SHIPPER', 'COMPANY_MANAGER')")
+	public ResponseEntity<ApiResponse<PageResponse<ListCompanyResponse>>> getCompanies(
+		@RequestParam(required = false) UUID hubId,
+		@RequestParam(required = false) String name,
+		@RequestParam(required = false) CompanyType type,
+		@ModelAttribute PageRequest pageRequest) {
+
+		GetCompaniesCommand command = GetCompaniesCommand.builder()
+			.hubId(hubId)
+			.name(name)
+			.type(type)
+			.pageRequest(pageRequest)
+			.build();
+		Page<CompanyResult> results = companyService.getCompanies(command);
+		
+		Page<ListCompanyResponse> responses = results.map(ListCompanyResponse::from);
+		return ResponseEntity.ok(ApiResponse.success(PageResponse.of(responses)));
 	}
 
 	@GetMapping("/{companyId}")

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/ApiResponse.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/ApiResponse.java
@@ -22,7 +22,7 @@ public record ApiResponse<T>(
 	 * 성공 응답 생성 (데이터 포함)
 	 */
 	public static <T> ApiResponse<T> success(T data) {
-		return new ApiResponse<>(true, null, data, System.currentTimeMillis());
+		return new ApiResponse<>(true, "요청에 성공했습니다.", data, System.currentTimeMillis());
 	}
 
 	/**

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/PageRequest.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/PageRequest.java
@@ -1,0 +1,20 @@
+package com.shoonglogitics.companyservice.presentation.company.common.dto;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record PageRequest (
+	Integer page,
+	PageSizeType size,
+	String sort,
+	Boolean isAsc
+) {
+	public Pageable toPageable() {
+		int pageNumber = (page != null && page >= 0) ? page : 0;
+		int pageSize = (size != null) ? size.getValue() : PageSizeType.SIZE_10.getValue();
+		String sortField = (sort != null && !sort.isBlank()) ? sort : "createdAt";
+		Sort.Direction direction = (isAsc != null && isAsc) ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+		return org.springframework.data.domain.PageRequest.of(pageNumber, pageSize, Sort.by(direction, sortField));
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/PageSizeType.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/common/dto/PageSizeType.java
@@ -1,0 +1,16 @@
+package com.shoonglogitics.companyservice.presentation.company.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum PageSizeType {
+	SIZE_10(10),
+	SIZE_30(30),
+	SIZE_50(50);
+
+	private final int value;
+
+	PageSizeType(int value) {
+		this.value = value;
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/dto/FindCompanyResponse.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/dto/FindCompanyResponse.java
@@ -1,0 +1,37 @@
+package com.shoonglogitics.companyservice.presentation.company.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.shoonglogitics.companyservice.application.dto.CompanyResult;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
+
+public record FindCompanyResponse(
+	UUID id,
+	UUID hubId,
+	String name,
+	String address,
+	String addressDetail,
+	String zipCode,
+	Double latitude,
+	Double longitude,
+	CompanyType type,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+	public static FindCompanyResponse from(CompanyResult result) {
+		return new FindCompanyResponse(
+			result.id(),
+			result.hubId(),
+			result.name(),
+			result.address(),
+			result.addressDetail(),
+			result.zipCode(),
+			result.latitude(),
+			result.longitude(),
+			result.type(),
+			result.createdAt(),
+			result.updatedAt()
+		);
+	}
+}

--- a/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/dto/ListCompanyResponse.java
+++ b/company-service/src/main/java/com/shoonglogitics/companyservice/presentation/company/dto/ListCompanyResponse.java
@@ -1,0 +1,25 @@
+package com.shoonglogitics.companyservice.presentation.company.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.shoonglogitics.companyservice.application.dto.CompanyResult;
+import com.shoonglogitics.companyservice.domain.company.vo.CompanyType;
+
+public record ListCompanyResponse(
+	UUID id,
+	UUID hubId,
+	String name,
+	CompanyType type,
+	LocalDateTime createdAt
+) {
+	public static ListCompanyResponse from(CompanyResult result) {
+		return new ListCompanyResponse(
+			result.id(),
+			result.hubId(),
+			result.name(),
+			result.type(),
+			result.createdAt()
+		);
+	}
+}


### PR DESCRIPTION
### 연관이슈(이슈번호)
#24 
### 변경사항
- 업체 상세 조회 API 구현
- 업체 목록 조회 API 구현
- 공통 PageReqeust 및 SIZE type 구현

### 리뷰요청
- 현재 PageReponse가 이전 PR에 포함되어있어 이전 PR포함시 오류 없이 실행 가능한 상태의 PR입니다.
그것만 제외하고 봐주시면 감사하겠습니다!!